### PR TITLE
docs: add LLVM-style comments to headers

### DIFF
--- a/include/btgly/codepoint.hh
+++ b/include/btgly/codepoint.hh
@@ -1,12 +1,19 @@
+//===- codepoint.hh - ASCII Code Point Utilities ----------------*- C++ -*-===//
 //
-// Created by Wael-Amine Boutglay on 05/06/2025.
+// Created by Wael-Amine Boutglay
 //
+// This file defines the CodePoint class which provides numeric constants for
+// ASCII characters and helper predicates for classifying individual code
+// points.
+//
+//===----------------------------------------------------------------------===//
 
 #pragma once
 
 namespace btgly {
 
-  //*-- CodePoint
+  /// CodePoint provides constants for ASCII characters and helper predicates
+  /// for classifying code points.
   class CodePoint {
   public:
     static const int NUL = 0x0000;
@@ -137,19 +144,34 @@ namespace btgly {
     static const int RBRACE = 0x007d;       // right brace ('}')
     static const int TILDE = 0x007e;        // tilde ('~')
 
+    /// Return true if `c` is either `0` or `1`.
     static bool isBinary(int c) { return $0 <= c && c <= $1; }
 
+    /// Return true if `c` is an octal digit.
     static bool isOctal(int c) { return $0 <= c && c <= $7; }
 
+    /// Return true if `c` is a decimal digit.
     static bool isDigit(int c) { return $0 <= c && c <= $9; }
 
-    static bool isHexadecimal(int c) { return ($0 <= c && c <= $9) || ($A <= c && c <= $F) || ($a <= c && c <= $f); }
+    /// Return true if `c` is a hexadecimal digit.
+    static bool isHexadecimal(int c) {
+      return ($0 <= c && c <= $9) || ($A <= c && c <= $F) ||
+             ($a <= c && c <= $f);
+    }
 
-    static bool isLetter(int c) { return ($A <= c && c <= $Z) || ($a <= c && c <= $z); }
+    /// Return true if `c` is an ASCII letter.
+    static bool isLetter(int c) {
+      return ($A <= c && c <= $Z) || ($a <= c && c <= $z);
+    }
 
+    /// Return true if `c` can start an identifier.
     static bool isNameStart(int c) { return isLetter(c); }
 
-    static bool isNamePart(int c) { return isLetter(c) || isDigit(c) || c == UNDERSCORE; }
+    /// Return true if `c` can appear after the first character of an
+    /// identifier.
+    static bool isNamePart(int c) {
+      return isLetter(c) || isDigit(c) || c == UNDERSCORE;
+    }
   };
 
 } // namespace btgly

--- a/include/btgly/kind.hh
+++ b/include/btgly/kind.hh
@@ -1,6 +1,11 @@
+//===- kind.hh - Runtime Kind Hierarchy Support ----------------*- C++ -*-===//
 //
-// Created by Wael-Amine Boutglay on 05/06/2025.
+// Created by Wael-Amine Boutglay
 //
+// This file declares a simple `Kind` class template that can be used to build
+// runtime type hierarchies for classification purposes.
+//
+//===----------------------------------------------------------------------===//
 
 #pragma once
 
@@ -8,32 +13,38 @@
 
 namespace btgly {
 
-  //*-- Kind
-  template<class T>
-  class Kind {
+  /// Kind implements a simple hierarchical classification that can be used to
+  /// describe relationships between runtime entities.
+  template <class T> class Kind {
   public:
-    explicit Kind(const char *name, const Kind<T> *parent_kind = nullptr) : _name(name), _parent_kind(parent_kind) {}
+    /// Construct a new `Kind` with the given name and optional parent kind.
+    explicit Kind(const char *name, const Kind<T> *parent_kind = nullptr)
+        : _name(name), _parent_kind(parent_kind) {}
 
+    /// Return the name of this kind.
     const std::string &name() const { return _name; }
 
+    /// Return the parent kind, or `nullptr` if this is a root kind.
     const Kind<T> *parent_kind() const { return _parent_kind; }
 
-    //*- methods
-
+    /// Return true if this kind is exactly `other`.
     bool is(const Kind<T> &other) const { return this == &other; }
 
+    /// Return true if this kind is a subkind of `other`.
     bool is_subkind_of(const Kind<T> &other) const {
       const Kind<T> *kind = this;
-      while(kind != nullptr) {
-        if(kind == &other) { return true; }
+      while (kind != nullptr) {
+        if (kind == &other) {
+          return true;
+        }
         kind = kind->_parent_kind;
       }
       return false;
     }
 
   private:
-    std::string _name;
-    const Kind<T> *_parent_kind;
+    std::string _name;              /// Name associated with this kind.
+    const Kind<T> *_parent_kind;    /// Parent kind or nullptr.
   };
 
-} // end namespace btgly
+} // namespace btgly


### PR DESCRIPTION
## Summary
- add LLVM-style header comment and documentation to `CodePoint`
- document `Kind` template and its helpers with LLVM-style comments
- restore author attribution line in header banners

## Testing
- `g++ -std=c++17 -fsyntax-only include/btgly/codepoint.hh include/btgly/kind.hh`


------
https://chatgpt.com/codex/tasks/task_e_688e76be62f48320951811ab682588d7