### PR TITLE
Handle zero-width BitVec

### DIFF
--- a/include/btgly/bitvec.hh
+++ b/include/btgly/bitvec.hh
@@ -31,7 +31,7 @@ namespace btgly {
     /// The value is reduced modulo 2^width (i.e., truncated to \p width bits).
     ///
     /// \param integer The textual integer value (e.g., "42", "0xff", "0b1010").
-    /// \param width   Number of bits. Must be > 0.
+    /// \param width   Number of bits (may be 0).
     static BitVec from_int(std::string s, std::size_t width);
 
     //*- properties


### PR DESCRIPTION
## Summary
- Allow constructing bit vectors of width 0 and guard sign/rotation helpers
- Fix shift amount comparison and zero-width rotation/extension behavior
- Expand and adjust tests for zero-width and small widths

## Testing
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68af07eb26388320af9ab20f1a27b1ba