### PR TITLE
Fast bitvectors for size<=64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_CXX_STANDARD 20)
 include_directories(include)
 
 add_library(btgly.bitvec STATIC src/bitvec.cc)
+add_library(btgly.strbitvec STATIC src/strbitvec.cc)
 
 include(FetchContent)
 FetchContent_Declare(
@@ -19,7 +20,7 @@ FetchContent_MakeAvailable(googletest)
 
 enable_testing()
 
-add_executable(btgly.bitvec.tests tests/bitvec_test.cc)
-target_link_libraries(btgly.bitvec.tests PRIVATE btgly.bitvec gtest_main)
+add_executable(btgly.bitvec.tests tests/bitvec_test.cc tests/strbitvec_test.cc)
+target_link_libraries(btgly.bitvec.tests PRIVATE btgly.bitvec btgly.strbitvec gtest_main)
 add_test(NAME bitvec_tests COMMAND btgly.bitvec.tests)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,20 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(googletest)
 
+# Google Benchmark for microbenchmarks
+FetchContent_Declare(
+        benchmark
+        URL https://github.com/google/benchmark/archive/refs/tags/v1.8.3.zip
+)
+FetchContent_MakeAvailable(benchmark)
+
 enable_testing()
 
-add_executable(btgly.bitvec.tests tests/bitvec_test.cc tests/strbitvec_test.cc)
+add_executable(btgly.bitvec.tests tests/bitvec_test.cc tests/strbitvec_test.cc tests/arith_fuzz_test.cc tests/width_property_test.cc)
 target_link_libraries(btgly.bitvec.tests PRIVATE btgly.bitvec btgly.strbitvec gtest_main)
 add_test(NAME bitvec_tests COMMAND btgly.bitvec.tests)
+
+# Microbenchmark target
+add_executable(bitvec_bench bench/bitvec_bench.cc)
+target_link_libraries(bitvec_bench PRIVATE btgly.bitvec btgly.strbitvec benchmark::benchmark)
 

--- a/bench/bitvec_bench.cc
+++ b/bench/bitvec_bench.cc
@@ -1,0 +1,182 @@
+#include <benchmark/benchmark.h>
+#include <btgly/bitvec.hh>
+#include <btgly/strbitvec.hh>
+#include <string>
+#include <vector>
+
+using namespace std;
+using btgly::BitVec;
+using btgly::StrBitVec;
+
+static const int widths[] = {1,5,8,13,16,25,32,55,64,99,128};
+
+// Helpers to generate test vectors
+
+template <typename BV>
+BV make_a(size_t w){ return BV::from_int("0x123456789ABCDEF", w); }
+
+template <typename BV>
+BV make_b(size_t w){ return BV::from_int("0xFEDCBA987654321", w); }
+
+template <typename BV>
+BV make_shift(size_t w){ return BV::from_int("1", w); }
+
+static void register_benchmarks(){
+  for(int w : widths){
+    // Bitwise AND
+    benchmark::RegisterBenchmark(("BitVec/and/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      BitVec a = make_a<BitVec>(w);
+      BitVec b = make_b<BitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.$and(b)); }
+    });
+    benchmark::RegisterBenchmark(("StrBitVec/and/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      StrBitVec a = make_a<StrBitVec>(w);
+      StrBitVec b = make_b<StrBitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.$and(b)); }
+    });
+
+    // Bitwise OR
+    benchmark::RegisterBenchmark(("BitVec/or/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      BitVec a = make_a<BitVec>(w);
+      BitVec b = make_b<BitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.$or(b)); }
+    });
+    benchmark::RegisterBenchmark(("StrBitVec/or/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      StrBitVec a = make_a<StrBitVec>(w);
+      StrBitVec b = make_b<StrBitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.$or(b)); }
+    });
+
+    // Bitwise XOR
+    benchmark::RegisterBenchmark(("BitVec/xor/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      BitVec a = make_a<BitVec>(w);
+      BitVec b = make_b<BitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.$xor(b)); }
+    });
+    benchmark::RegisterBenchmark(("StrBitVec/xor/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      StrBitVec a = make_a<StrBitVec>(w);
+      StrBitVec b = make_b<StrBitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.$xor(b)); }
+    });
+
+    // Shifts
+    benchmark::RegisterBenchmark(("BitVec/shl/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      BitVec a = make_a<BitVec>(w);
+      BitVec amt = make_shift<BitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.shl(amt)); }
+    });
+    benchmark::RegisterBenchmark(("StrBitVec/shl/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      StrBitVec a = make_a<StrBitVec>(w);
+      StrBitVec amt = make_shift<StrBitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.shl(amt)); }
+    });
+    benchmark::RegisterBenchmark(("BitVec/lshr/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      BitVec a = make_a<BitVec>(w);
+      BitVec amt = make_shift<BitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.lshr(amt)); }
+    });
+    benchmark::RegisterBenchmark(("StrBitVec/lshr/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      StrBitVec a = make_a<StrBitVec>(w);
+      StrBitVec amt = make_shift<StrBitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.lshr(amt)); }
+    });
+    benchmark::RegisterBenchmark(("BitVec/ashr/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      BitVec a = make_a<BitVec>(w);
+      BitVec amt = make_shift<BitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.ashr(amt)); }
+    });
+    benchmark::RegisterBenchmark(("StrBitVec/ashr/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      StrBitVec a = make_a<StrBitVec>(w);
+      StrBitVec amt = make_shift<StrBitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.ashr(amt)); }
+    });
+
+    // Arithmetic
+    benchmark::RegisterBenchmark(("BitVec/add/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      BitVec a = make_a<BitVec>(w);
+      BitVec b = make_b<BitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.add(b)); }
+    });
+    benchmark::RegisterBenchmark(("StrBitVec/add/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      StrBitVec a = make_a<StrBitVec>(w);
+      StrBitVec b = make_b<StrBitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.add(b)); }
+    });
+    benchmark::RegisterBenchmark(("BitVec/sub/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      BitVec a = make_a<BitVec>(w);
+      BitVec b = make_b<BitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.sub(b)); }
+    });
+    benchmark::RegisterBenchmark(("StrBitVec/sub/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      StrBitVec a = make_a<StrBitVec>(w);
+      StrBitVec b = make_b<StrBitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.sub(b)); }
+    });
+    benchmark::RegisterBenchmark(("BitVec/mul/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      BitVec a = make_a<BitVec>(w);
+      BitVec b = make_b<BitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.mul(b)); }
+    });
+    benchmark::RegisterBenchmark(("StrBitVec/mul/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      StrBitVec a = make_a<StrBitVec>(w);
+      StrBitVec b = make_b<StrBitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.mul(b)); }
+    });
+    benchmark::RegisterBenchmark(("BitVec/udiv/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      BitVec a = make_a<BitVec>(w);
+      BitVec b = make_b<BitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.udiv(b)); }
+    });
+    benchmark::RegisterBenchmark(("StrBitVec/udiv/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      StrBitVec a = make_a<StrBitVec>(w);
+      StrBitVec b = make_b<StrBitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.udiv(b)); }
+    });
+    benchmark::RegisterBenchmark(("BitVec/sdiv/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      BitVec a = make_a<BitVec>(w);
+      BitVec b = make_b<BitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.sdiv(b)); }
+    });
+    benchmark::RegisterBenchmark(("StrBitVec/sdiv/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      StrBitVec a = make_a<StrBitVec>(w);
+      StrBitVec b = make_b<StrBitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.sdiv(b)); }
+    });
+
+    // Comparisons
+    benchmark::RegisterBenchmark(("BitVec/eq/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      BitVec a = make_a<BitVec>(w);
+      BitVec b = make_b<BitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.eq(b)); }
+    });
+    benchmark::RegisterBenchmark(("StrBitVec/eq/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      StrBitVec a = make_a<StrBitVec>(w);
+      StrBitVec b = make_b<StrBitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.eq(b)); }
+    });
+    benchmark::RegisterBenchmark(("BitVec/ult/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      BitVec a = make_a<BitVec>(w);
+      BitVec b = make_b<BitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.ult(b)); }
+    });
+    benchmark::RegisterBenchmark(("StrBitVec/ult/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      StrBitVec a = make_a<StrBitVec>(w);
+      StrBitVec b = make_b<StrBitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.ult(b)); }
+    });
+    benchmark::RegisterBenchmark(("BitVec/slt/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      BitVec a = make_a<BitVec>(w);
+      BitVec b = make_b<BitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.slt(b)); }
+    });
+    benchmark::RegisterBenchmark(("StrBitVec/slt/"+to_string(w)).c_str(), [w](benchmark::State& st){
+      StrBitVec a = make_a<StrBitVec>(w);
+      StrBitVec b = make_b<StrBitVec>(w);
+      for(auto _ : st){ benchmark::DoNotOptimize(a.slt(b)); }
+    });
+  }
+}
+
+static int bench_registrar = (register_benchmarks(), 0);
+
+BENCHMARK_MAIN();

--- a/include/btgly/strbitvec.hh
+++ b/include/btgly/strbitvec.hh
@@ -1,0 +1,361 @@
+//
+// Created by Wael-Amine Boutglay on 26/08/2025.
+//
+
+#pragma once
+
+#include <vector>
+#include <string>
+#include "btgly/codepoint.hh"
+#include "btgly/radix.hh"
+
+namespace btgly {
+
+  //*-- StrBitVec
+
+  /// \brief Fixed-width bit-vector with SMT-LIB–style semantics.
+  class StrBitVec {
+  public:
+    explicit StrBitVec(std::size_t width);
+
+    StrBitVec(bool value, std::size_t width);
+
+    static StrBitVec zeros(std::size_t width);
+
+    static StrBitVec ones(std::size_t width);
+
+    /// \brief Construct a bit-vector of \p width from an integer string.
+    ///
+    /// Parses \p integer as an unsigned integer in base 10 by default, or in
+    /// base 2/8/16 when prefixed with \c 0b / \c 0o / \c 0x respectively.
+    /// The value is reduced modulo 2^width (i.e., truncated to \p width bits).
+    ///
+    /// \param integer The textual integer value (e.g., "42", "0xff", "0b1010").
+    /// \param width   Number of bits (may be 0).
+    static StrBitVec from_int(std::string s, std::size_t width);
+
+    //*- properties
+
+    const std::vector<bool> &bits() const { return _bits; }
+
+    /// \brief Return the number of bits in this bit-vector.
+    std::size_t width() const;
+
+    bool is_all_ones() const;
+
+    bool is_zero() const;
+
+    bool is_negative() const;
+
+    bool is_most_negative() const;
+
+    //*- methods
+
+    /// \brief Concatenate this bit-vector (high part) with \p rhs (low part).
+    ///
+    /// \param rhs Low-order bits to append.
+    /// \returns A new bit-vector of combined width.
+    StrBitVec concat(const StrBitVec &rhs) const;
+
+    /// \brief Extract bits \c [i : j] (inclusive), with \c i >= j.
+    ///
+    /// Uses 0-based indexing where bit 0 is LSB. The result has width \c i-j+1
+    /// with result[0] = original bit \c j.
+    ///
+    /// \param i High bit index (inclusive).
+    /// \param j Low bit index  (inclusive).
+    /// \returns A new bit-vector of width \c (i - j + 1).
+    StrBitVec extract(std::size_t i, std::size_t j) const;
+
+    /// \brief Repeat this bit-vector \p k times by concatenation.
+    ///
+    /// \param k Number of repetitions (k >= 0). If \p k == 0, the result has
+    /// width 0.
+    /// \returns A new bit-vector of width \c k * this->width().
+    StrBitVec repeat(std::size_t k) const;
+
+    /// \brief Sign-extend by \p k bits (two's-complement).
+    ///
+    /// High bits of the result are filled with the sign bit (original bit
+    /// \c width()-1). Result width is \c width()+k.
+    ///
+    /// \param k Number of bits to add.
+    StrBitVec sign_extend(std::size_t k) const;
+
+    /// \brief Zero-extend by \p k bits.
+    ///
+    /// High bits of the result are filled with zeros. Result width is
+    /// \c width()+k.
+    ///
+    /// \param k Number of bits to add.
+    StrBitVec zero_extend(std::size_t k) const;
+
+    /// \brief Rotate left by \p k (mod \c width()).
+    ///
+    /// \param k Rotation amount (any size; taken modulo \c width()).
+    /// \returns A bitwise rotation; width unchanged.
+    StrBitVec rotate_left(std::size_t k) const;
+
+    /// \brief Rotate right by \p k (mod \c width()).
+    ///
+    /// \param k Rotation amount (any size; taken modulo \c width()).
+    /// \returns A bitwise rotation; width unchanged.
+    StrBitVec rotate_right(std::size_t k) const;
+
+    /// \brief Bitwise NOT (~).
+    ///
+    /// \returns A bit-vector where each bit is inverted.
+    StrBitVec $not() const;
+
+    /// \brief Bitwise AND.
+    ///
+    /// \param rhs Right-hand operand (same width).
+    /// \returns \c (*this) & rhs.
+    StrBitVec $and(const StrBitVec &rhs) const;
+
+    /// \brief Bitwise OR.
+    ///
+    /// \param rhs Right-hand operand (same width).
+    /// \returns \c (*this) | rhs.
+    StrBitVec $or(const StrBitVec &rhs) const;
+
+    /// \brief Bitwise XOR.
+    ///
+    /// \param rhs Right-hand operand (same width).
+    /// \returns \c (*this) ^ rhs.
+    StrBitVec $xor(const StrBitVec &rhs) const;
+
+    /// \brief Bitwise NAND: NOT(AND).
+    ///
+    /// \param rhs Right-hand operand (same width).
+    /// \returns \c ~((*this) & rhs).
+    StrBitVec nand(const StrBitVec &rhs) const;
+
+    /// \brief Bitwise NOR: NOT(OR).
+    ///
+    /// \param rhs Right-hand operand (same width).
+    /// \returns \c ~((*this) | rhs).
+    StrBitVec nor(const StrBitVec &rhs) const;
+
+    /// \brief Bitwise XNOR: NOT(XOR).
+    ///
+    /// \param rhs Right-hand operand (same width).
+    /// \returns \c ~((*this) ^ rhs).
+    StrBitVec xnor(const StrBitVec &rhs) const;
+
+    /// \brief Reduction AND.
+    ///
+    /// \returns \c true iff all bits are 1 (width==0 returns \c true).
+    bool redand() const;
+
+    /// \brief Reduction OR.
+    ///
+    /// \returns \c true iff any bit is 1 (width==0 returns \c false).
+    bool redor() const;
+
+    /// \brief Two's-complement negation.
+    ///
+    /// Equivalent to \c (~x + 1) modulo 2^width. Overflow (negation overflow)
+    /// occurs only for the most-negative value (1000...0).
+    StrBitVec neg() const;
+
+    /// \brief Unsigned/signed-agnostic modular addition.
+    ///
+    /// Result is \c (*this + rhs) mod 2^width.
+    StrBitVec add(const StrBitVec &rhs) const;
+
+    /// \brief Unsigned/signed-agnostic modular subtraction.
+    ///
+    /// Result is \c (*this - rhs) mod 2^width.
+    StrBitVec sub(const StrBitVec &rhs) const;
+
+    /// \brief Unsigned/signed-agnostic modular multiplication.
+    ///
+    /// Result is \c (*this * rhs) mod 2^width.
+    StrBitVec mul(const StrBitVec &rhs) const;
+
+    /// \brief Unsigned division (SMT-LIB \c bvudiv semantics), Div/0 -> all ones.
+    ///
+    /// \param rhs Divisor.
+    /// \returns \c floor(u(*this) / u(rhs)), where \c u is the unsigned value.
+    /// Division by zero yields a vector of all 1s.
+    StrBitVec udiv(const StrBitVec &rhs) const;
+
+    /// \brief Unsigned remainder (SMT-LIB \c bvurem semantics), Div/0 -> lhs.
+    ///
+    /// \param rhs Divisor.
+    /// \returns \c u(*this) mod u(rhs). If \p rhs is zero, returns \c *this.
+    StrBitVec urem(const StrBitVec &rhs) const;
+
+    /// \brief Signed division (two's-complement; SMT-LIB \c bvsdiv semantics).
+    /// Div/0 -> -1. Overflow (min / -1) -> min.
+    ///
+    /// \returns Truncating division toward zero on signed values. Division by
+    /// zero yields all 1s (i.e., -1). The overflow case (most-negative / -1)
+    /// returns most-negative.
+    StrBitVec sdiv(const StrBitVec &rhs) const;
+
+    /// \brief Signed remainder (SMT-LIB \c bvsrem semantics).
+    /// Div/0 -> lhs. Overflow (min / -1) -> 0.
+    ///
+    /// \returns \c s(*this) - trunc(s(*this)/s(rhs)) * s(rhs), where \c s is the
+    /// signed value. If \p rhs is zero, returns \c *this. In the overflow case
+    /// (most-negative / -1), returns 0.
+    StrBitVec srem(const StrBitVec &rhs) const;
+
+    /// \brief Signed modulo (SMT-LIB \c bvsmod semantics).
+    /// Div/0 -> lhs. Overflow (min / -1) -> 0.
+    ///
+    /// \returns A value with the sign of \p rhs and magnitude < |rhs|. If
+    /// \p rhs is zero, returns \c *this. In the overflow case
+    /// (most-negative / -1), returns 0.
+    StrBitVec smod(const StrBitVec &rhs) const;
+
+    /// \brief Logical left shift by an unsigned amount in \p rhs.
+    ///
+    /// Shift amount is interpreted as an unsigned integer from \p rhs. If the
+    /// amount >= width, the result is all zeros.
+    StrBitVec shl(const StrBitVec &rhs) const;
+
+    /// \brief Logical right shift by an unsigned amount in \p rhs.
+    ///
+    /// Shift amount is interpreted as unsigned. If the amount >= width, the
+    /// result is all zeros.
+    StrBitVec lshr(const StrBitVec &rhs) const;
+
+    /// \brief Arithmetic right shift by an unsigned amount in \p rhs.
+    ///
+    /// Vacated bits are filled with the sign bit. If the amount >= width, the
+    /// result is all sign bits (all 0s for non-negative, all 1s for negative).
+    StrBitVec ashr(const StrBitVec &rhs) const;
+
+    /// \brief Unsigned comparison: \c *this < rhs.
+    bool ult(const StrBitVec &rhs) const;
+
+    /// \brief Unsigned comparison: \c *this \<= rhs.
+    bool ule(const StrBitVec &rhs) const;
+
+    /// \brief Unsigned comparison: \c *this \>= rhs.
+    bool uge(const StrBitVec &rhs) const;
+
+    /// \brief Unsigned comparison: \c *this > rhs.
+    bool ugt(const StrBitVec &rhs) const;
+
+    bool eq(const StrBitVec &rhs) const;
+
+    bool equals(const StrBitVec &rhs) const;
+
+    /// \brief Signed comparison: \c *this < rhs.
+    bool slt(const StrBitVec &rhs) const;
+
+    /// \brief Signed comparison: \c *this \<= rhs.
+    bool sle(const StrBitVec &rhs) const;
+
+    /// \brief Signed comparison: \c *this \>= rhs.
+    bool sge(const StrBitVec &rhs) const;
+
+    /// \brief Signed comparison: \c *this > rhs.
+    bool sgt(const StrBitVec &rhs) const;
+
+    /// \brief Bit-vector compare (SMT-LIB \c bvcomp).
+    ///
+    /// \returns A 1-bit vector equal to 1 iff \c *this == rhs, else 0.
+    StrBitVec comp(const StrBitVec &rhs) const;
+
+    /// \brief Negation overflow predicate.
+    ///
+    /// \returns \c true iff \c *this is the most-negative two's-complement value.
+    bool nego() const;
+
+    /// \brief Unsigned addition overflow.
+    ///
+    /// \returns \c true iff \c u(*this) + u(rhs) >= 2^width.
+    bool uaddo(const StrBitVec &rhs) const;
+
+    /// \brief Signed addition overflow.
+    ///
+    /// \returns \c true iff adding as signed two's-complement overflows.
+    bool saddo(const StrBitVec &rhs) const;
+
+    /// \brief Unsigned multiplication overflow.
+    ///
+    /// \returns \c true iff the full unsigned product does not fit in \c width
+    /// bits (i.e., any high bits beyond width are non-zero).
+    bool umulo(const StrBitVec &rhs) const;
+
+    /// \brief Signed multiplication overflow.
+    ///
+    /// \returns \c true iff the exact two's-complement product cannot be
+    /// represented in \c width bits.
+    bool smulo(const StrBitVec &rhs) const;
+
+    /// \brief Unsigned subtraction overflow (borrow).
+    ///
+    /// \returns \c true iff \c u(*this) < u(rhs) (i.e., a borrow occurs).
+    bool usubo(const StrBitVec &rhs) const;
+
+    /// \brief Signed subtraction overflow.
+    ///
+    /// \returns \c true iff subtracting as signed two's-complement overflows.
+    bool ssubo(const StrBitVec &rhs) const;
+
+    /// \brief Signed division overflow.
+    ///
+    /// \returns \c true iff \c *this is most-negative and \p rhs is -1 (the only
+    /// overflowing signed divide in two's-complement).
+    bool sdivo(const StrBitVec &rhs) const;
+
+    /// \brief Return the unsigned decimal string representation.
+    ///
+    /// \returns The value interpreted as an unsigned integer, in base 10.
+    std::string u_to_int() const;
+
+    /// \brief Return the signed decimal string representation.
+    ///
+    /// \returns The value interpreted as a signed two's-complement integer,
+    /// in base 10.
+    std::string s_to_int() const;
+
+  private:
+    /// \brief Bit storage (LSB-first; index 0 is the least significant bit).
+    std::vector<bool> _bits;
+
+    static bool _is_decimal_zero(const std::string &s);
+
+    static int _div_decimal_by_2(std::string &s);
+
+    static void _trim_leading_zeros(std::string &s);
+
+    // Add a*b into 'acc' (acc has size >= a.size()+b.size())
+    static void _mul(std::vector<bool> &acc, const std::vector<bool> &a, const std::vector<bool> &b);
+
+    // TODO: static + rename to ucomp
+    static int _compare_unsigned(const StrBitVec &a, const StrBitVec &b);
+
+    // Unsigned division: compute quotient q (size w) and remainder r (dynamic).
+    static void _udivrem_bits(const std::vector<bool> &num, const std::vector<bool> &den, std::vector<bool> &q,
+                              std::vector<bool> &r);
+
+    // Compare arbitrary-length LSB-first vectors (unsigned).
+    static int _cmp_arb_unsigned(const std::vector<bool> &a, const std::vector<bool> &b);
+
+    // a -= b, assumes a >= b (unsigned), arbitrary-length LSB-first.
+    static void _sub_arb_unsigned_in_place(std::vector<bool> &a, const std::vector<bool> &b);
+
+    static void _trim_bits(std::vector<bool> &v);
+
+    static int _msb_index(const std::vector<bool> &v);
+
+    static void _dec_mul_add(std::string &s, int mul, int add);
+
+    static std::size_t _rhs_amount_mod(const StrBitVec &amt, std::size_t mod);
+
+    static bool _rhs_amount_ge_width(const StrBitVec &amt, std::size_t w);
+
+    /*void ensureSameWidth(const StrBitVec &rhs, const char *op) const {
+        if (width() != rhs.width())
+          throw std::invalid_argument(std::string(op) + ": width mismatch");
+    }*/
+  };
+
+} // namespace btgly

--- a/src/strbitvec.cc
+++ b/src/strbitvec.cc
@@ -1,0 +1,816 @@
+//
+// Created by Wael-Amine Boutglay on 26/08/2025.
+//
+
+#include "btgly/strbitvec.hh"
+#include <stdexcept>
+
+namespace btgly {
+
+  //*-- StrBitVec
+
+  StrBitVec::StrBitVec(std::size_t width) : _bits(width) {}
+
+  StrBitVec::StrBitVec(bool value, std::size_t width) : _bits(width, value) {}
+
+  StrBitVec StrBitVec::zeros(std::size_t width) { return StrBitVec(0, width); }
+
+  StrBitVec StrBitVec::ones(std::size_t width) { return StrBitVec(1, width); }
+
+  StrBitVec StrBitVec::from_int(std::string s, std::size_t width) {
+    // TODO: specify
+    // TODO: deal with empty or illegal string
+    StrBitVec result(width);
+
+    // determine negativeness
+    bool neg = false;
+    if(s[0] == '+' || s[0] == '-') {
+      neg = (s[0] == '-');
+      s.erase(s.begin());
+    }
+
+    // determine base
+    Radix base = Radix::Decimal;
+    if(s.size() >= 2 && s[0] == CodePoint::$0 &&
+       (s[1] == CodePoint::$b || s[1] == CodePoint::$B || s[1] == CodePoint::$x || s[1] == CodePoint::$X ||
+        s[1] == CodePoint::$o || s[1] == CodePoint::$O)) {
+      char p = s[1];
+      if(p == CodePoint::$b || p == CodePoint::$B) {
+        base = Radix::Binary;
+      } else if(p == CodePoint::$o || p == CodePoint::$O) {
+        base = Radix::Octal;
+      } else {
+        base = Radix::Hexadecimal;
+      }
+      s.erase(0, 2);
+    }
+
+    if(base == Radix::Binary) { // parse binary integer
+      std::size_t pos = 0;
+      for(std::size_t k = 0; k < s.size(); ++k) {
+        char c = s[s.size() - 1 - k];
+        if(c != CodePoint::$0 && c != CodePoint::$1) { throw std::invalid_argument("invalid binary digit"); }
+        if(pos < width) { result._bits[pos] = (c == CodePoint::$1); }
+        ++pos;
+      }
+    } else if(base == Radix::Octal) { // parse octal integer
+      std::size_t pos = 0;
+      for(std::size_t k = 0; k < s.size(); ++k) {
+        char c = s[s.size() - 1 - k];
+        if(c < CodePoint::$0 || c > CodePoint::$7) { throw std::invalid_argument("invalid octal digit"); }
+        int v = c - CodePoint::$0;
+        for(int b = 0; b < 3; ++b) {
+          if(pos < width) { result._bits[pos] = (v >> b) & 1; }
+          ++pos;
+        }
+      }
+    } else if(base == Radix::Hexadecimal) { // parse hex integer
+      std::size_t pos = 0;
+      for(std::size_t k = 0; k < s.size(); ++k) {
+        int v = CodePoint::hex_to_int(s[s.size() - 1 - k]);
+        if(v < 0) { throw std::invalid_argument("invalid hexadecimal digit"); }
+        for(int b = 0; b < 4; ++b) {
+          if(pos < width) { result._bits[pos] = (v >> b) & 1; }
+          ++pos;
+        }
+      }
+    } else { // parse decimal integer
+      std::string dec = s;
+      std::size_t pos = 0;
+      while(!_is_decimal_zero(dec) && pos < width) {
+        int rem = _div_decimal_by_2(dec);
+        result._bits[pos++] = (rem != 0);
+      }
+    }
+
+    // negate if negative
+    if(neg) { result = result.neg(); }
+
+    return result;
+  }
+
+  //*- properties
+
+  std::size_t StrBitVec::width() const { return _bits.size(); }
+
+  bool StrBitVec::is_all_ones() const { return redand(); }
+
+  bool StrBitVec::is_zero() const { return !redor(); }
+
+  bool StrBitVec::is_negative() const {
+    return width() == 0 ? false : _bits[width() - 1];
+  }
+
+  bool StrBitVec::is_most_negative() const {
+    const std::size_t w = width();
+    if(w == 0) { return false; }
+    if(!_bits[w - 1]) {
+      return false; // sign bit must be 1
+    }
+    for(std::size_t i = 0; i + 1 < w; ++i) {
+      if(_bits[i]) return false; // all others must be 0
+    }
+    return true;
+  }
+
+  //*- methods
+
+  StrBitVec StrBitVec::concat(const StrBitVec &rhs) const {
+    //$ ensures return.width() == this.width() + rhs.width()
+    //$ ensures forall k: Int :: 0 <= k < rhs.width() => return[k] == rhs[k]
+    //$ ensures forall k: Int :: 0 <= k < this.width() => return[rhs.width() + k] == this[k]
+    StrBitVec result(this->width() + rhs.width());
+    // Low part from rhs
+    for(std::size_t i = 0; i < rhs.width(); ++i) { result._bits[i] = rhs._bits[i]; }
+    // High part from this
+    for(std::size_t i = 0; i < this->width(); ++i) { result._bits[i + rhs.width()] = _bits[i]; }
+    return result;
+  }
+
+  StrBitVec StrBitVec::extract(std::size_t i, std::size_t j) const {
+    // TODO: specify
+    if(i < j) { throw std::invalid_argument("extract: i < j"); }
+    if(i >= this->width()) { throw std::out_of_range("extract: high index out of range"); }
+    const std::size_t w = i - j + 1;
+    StrBitVec result(w);
+    for(std::size_t k = 0; k < w; ++k) {
+      const std::size_t src = j + k;
+      result._bits[k] = _bits[src];
+    }
+    return result;
+  }
+
+  StrBitVec StrBitVec::repeat(std::size_t k) const {
+    // TODO: specify
+    if(k == 0) { return StrBitVec::zeros(0); }
+    StrBitVec result(width() * k);
+    for(std::size_t r = 0; r < k; ++r) {
+      for(std::size_t i = 0; i < this->width(); ++i) { result._bits[r * this->width() + i] = _bits[i]; }
+    }
+    return result;
+  }
+
+  StrBitVec StrBitVec::sign_extend(std::size_t k) const {
+    // TODO: specify
+    StrBitVec result(0, this->width() + k);
+    const bool sign = width() == 0 ? false : _bits[width() - 1];
+    for(std::size_t i = 0; i < this->width(); ++i) { result._bits[i] = _bits[i]; }
+    for(std::size_t i = this->width(); i < result.width(); ++i) { result._bits[i] = sign; }
+    return result;
+  }
+
+  StrBitVec StrBitVec::zero_extend(std::size_t k) const {
+    // TODO: specify
+    StrBitVec out(0, width() + k);
+    for(std::size_t i = 0; i < width(); ++i) { out._bits[i] = _bits[i]; }
+    return out;
+  }
+
+  StrBitVec StrBitVec::rotate_left(std::size_t k) const {
+    // TODO: specify
+    const std::size_t w = width();
+    if(w == 0) return StrBitVec(0);
+    k %= w;
+    StrBitVec out(w);
+    for(std::size_t i = 0; i < w; ++i) {
+      // new[i] = old[(i - k) mod w]
+      const std::size_t src = (i + w - (k % w)) % w;
+      out._bits[i] = _bits[src];
+    }
+    return out;
+  }
+
+  StrBitVec StrBitVec::rotate_right(std::size_t k) const {
+    // TODO: specify
+    const std::size_t w = width();
+    if(w == 0) return StrBitVec(0);
+    k %= w;
+    StrBitVec out(w);
+    for(std::size_t i = 0; i < w; ++i) {
+      // new[i] = old[(i + k) mod w]
+      const std::size_t src = (i + (k % w)) % w;
+      out._bits[i] = _bits[src];
+    }
+    return out;
+  }
+
+  StrBitVec StrBitVec::$not() const {
+    //$ ensures return.width() == this.width()
+    //$ ensures forall k: Int :: 0 <= k < rhs.width() => return[k] == !this[k]
+    StrBitVec result(this->width());
+    for(std::size_t i = 0; i < width(); ++i) { result._bits[i] = !_bits[i]; }
+    return result;
+  }
+
+  StrBitVec StrBitVec::$and(const StrBitVec &rhs) const {
+    //$ requires rhs.width() == this.width()
+    //$ ensures return.width() == this.width()
+    //$ ensures forall k: Int :: 0 <= k < rhs.width() => return[k] == (this[k] && rhs[k])
+    // TODO: ensureSameWidth(rhs, "$and");
+    StrBitVec result(width());
+    for(std::size_t i = 0; i < width(); ++i) { result._bits[i] = _bits[i] & rhs._bits[i]; }
+    return result;
+  }
+
+  StrBitVec StrBitVec::$or(const StrBitVec &rhs) const {
+    //$ requires rhs.width() == this.width()
+    //$ ensures return.width() == this.width()
+    //$ ensures forall k: Int :: 0 <= k < rhs.width() => return[k] == (this[k] || rhs[k])
+    // TODO: ensureSameWidth(rhs, "or");
+    StrBitVec result(width());
+    for(std::size_t i = 0; i < width(); ++i) { result._bits[i] = _bits[i] | rhs._bits[i]; }
+    return result;
+  }
+
+  StrBitVec StrBitVec::$xor(const StrBitVec &rhs) const {
+    //$ requires rhs.width() == this.width()
+    //$ ensures return.width() == this.width()
+    //$ ensures forall k: Int :: 0 <= k < rhs.width() => return[k] == (this[k] ^ rhs[k])
+    // TODO: ensureSameWidth(rhs, "$xor");
+    StrBitVec result(width());
+    for(std::size_t i = 0; i < width(); ++i) { result._bits[i] = _bits[i] ^ rhs._bits[i]; }
+    return result;
+  }
+
+  StrBitVec StrBitVec::nand(const StrBitVec &rhs) const {
+    // TODO: specify
+    return $and(rhs).$not();
+  }
+
+  StrBitVec StrBitVec::nor(const StrBitVec &rhs) const {
+    // TODO: specify
+    return $or(rhs).$not();
+  }
+
+  StrBitVec StrBitVec::xnor(const StrBitVec &rhs) const {
+    // TODO: specify
+    return $xor(rhs).$not();
+  }
+
+  bool StrBitVec::redand() const {
+    // TODO: specify
+    for(bool b: _bits) {
+      if(!b) { return false; }
+    }
+    return true;
+  }
+
+  bool StrBitVec::redor() const {
+    // TODO: specify
+    for(bool b: _bits) {
+      if(b) { return true; };
+    }
+    return false;
+  }
+
+  StrBitVec StrBitVec::neg() const {
+    //$ ensures return.width() == this.width()
+    // TODO: specify
+    // Return 0 - this (mod 2^w)
+    return StrBitVec::zeros(this->width()).sub(*this);
+  }
+
+  StrBitVec StrBitVec::add(const StrBitVec &rhs) const {
+    //$ requires rhs.width() == this.width()
+    //$ ensures return.width() == this.width()
+    // TODO: specify
+    // TODO: ensureSameWidth(rhs, "add");
+    StrBitVec result(this->width());
+    bool carry = false;
+    for(std::size_t i = 0; i < width(); ++i) {
+      const bool a = _bits[i], b = rhs._bits[i];
+      result._bits[i] = (a ^ b) ^ carry;
+      carry = (a & b) | (a & carry) | (b & carry);
+    }
+    return result;
+  }
+
+  StrBitVec StrBitVec::sub(const StrBitVec &rhs) const {
+    //$ requires rhs.width() == this.width()
+    //$ ensures return.width() == this.width()
+    // TODO: specify
+    // TODO: ensureSameWidth(rhs, "sub");
+    StrBitVec result(width());
+    bool borrow = false;
+    for(std::size_t i = 0; i < width(); ++i) {
+      const bool a = _bits[i], b = rhs._bits[i];
+      result._bits[i] = (a ^ b) ^ borrow;
+      borrow = (!a & b) | ((!(a) | b) & borrow);
+    }
+    return result;
+  }
+
+  StrBitVec StrBitVec::mul(const StrBitVec &rhs) const {
+    // TODO: specify
+    // TODO:ensureSameWidth(rhs, "mul");
+    const std::size_t w = this->width();
+    // Compute full 2w-bit product, return low w bits.
+    std::vector<bool> full(2 * w, false);
+    _mul(full, _bits, rhs._bits);
+    StrBitVec out(w);
+    for(std::size_t i = 0; i < w; ++i) { out._bits[i] = full[i]; }
+    return out;
+  }
+
+  StrBitVec StrBitVec::udiv(const StrBitVec &rhs) const {
+    // TODO:specify
+    // TODO: ensureSameWidth(rhs, "udiv");
+    const std::size_t w = width();
+    if(rhs.is_zero()) { return StrBitVec::ones(w); }
+    std::vector<bool> q(w, false), r; // remainder dynamic
+    _udivrem_bits(_bits, rhs._bits, q, r);
+    StrBitVec out(w);
+    out._bits = std::move(q);
+    return out;
+  }
+
+  StrBitVec StrBitVec::urem(const StrBitVec &rhs) const {
+    // TODO:specify
+    // TODO: ensureSameWidth(rhs, "urem");
+    const std::size_t w = width();
+    if(rhs.is_zero()) return *this;
+    std::vector<bool> q(w, false), r;
+    _udivrem_bits(_bits, rhs._bits, q, r);
+    StrBitVec out(w);
+    // copy low w bits of r
+    for(std::size_t i = 0; i < w && i < r.size(); ++i) { out._bits[i] = r[i]; }
+    return out;
+  }
+
+  StrBitVec StrBitVec::sdiv(const StrBitVec &rhs) const {
+    // TODO: specify
+    //TODO: ensureSameWidth(rhs, "sdiv");
+    const std::size_t w = width();
+    if(rhs.is_zero()) {
+      return StrBitVec::ones(w); // -1
+    }
+    if(is_most_negative() && rhs.is_all_ones()) {
+      return *this; // overflow case
+    }
+
+    const bool negA = is_negative();
+    const bool negB = rhs.is_negative();
+
+    StrBitVec aMag = negA ? this->neg() : *this;
+    StrBitVec bMag = negB ? rhs.neg() : rhs;
+
+    StrBitVec q = aMag.udiv(bMag);
+    if(negA ^ negB) { q = q.neg(); }
+    return q;
+  }
+
+  StrBitVec StrBitVec::srem(const StrBitVec &rhs) const {
+    // TODO: specify
+    // TODO: ensureSameWidth(rhs, "srem");
+    const std::size_t w = width();
+    if(rhs.is_zero()) { return *this; }
+    if(is_most_negative() && rhs.is_all_ones()) {
+      return StrBitVec::zeros(w); // 0
+    }
+
+    const bool negA = is_negative();
+    const bool negB = rhs.is_negative();
+
+    StrBitVec aMag = negA ? this->neg() : *this;
+    StrBitVec bMag = negB ? rhs.neg() : rhs;
+
+    StrBitVec r = aMag.urem(bMag);
+    if(negA) { r = r.neg(); }
+    return r;
+  }
+
+  StrBitVec StrBitVec::smod(const StrBitVec &rhs) const {
+    // TODO: specify
+    // TODO: ensureSameWidth(rhs, "smod");
+    const std::size_t w = width();
+    if(w == 0) return StrBitVec(0);
+    if(rhs.is_zero()) { return *this; }
+    if(is_most_negative() && rhs.is_all_ones()) return StrBitVec(w); // 0
+
+    StrBitVec r = srem(rhs);
+    if(r.is_zero()) { return r; }
+
+    const bool signR = r.is_negative();
+    const bool signY = rhs.is_negative();
+
+    if(signR != signY) {
+      // r += y (mod 2^w)
+      r = r.add(rhs);
+    }
+    return r;
+  }
+
+  StrBitVec StrBitVec::shl(const StrBitVec &rhs) const {
+    // TODO: specify
+    // TODO: ensureSameWidth(rhs, "shl");
+    const std::size_t w = width();
+    bool ge = _rhs_amount_ge_width(rhs, w);
+    if(ge) {
+      return StrBitVec::zeros(w); // all zeros
+    }
+    std::size_t amt = _rhs_amount_mod(rhs, w); // exact, since < w
+    StrBitVec out(w);
+    for(std::size_t i = w; i-- > 0;) {
+      if(i >= amt) out._bits[i] = _bits[i - amt];
+    }
+    return out;
+  }
+
+  StrBitVec StrBitVec::lshr(const StrBitVec &rhs) const {
+    // TODO: specify
+    // TODO: ensureSameWidth(rhs, "lshr");
+    const std::size_t w = width();
+    bool ge = _rhs_amount_ge_width(rhs, w);
+    if(ge) {
+      return StrBitVec::zeros(w); // all zeros
+    }
+    std::size_t amt = _rhs_amount_mod(rhs, w);
+    StrBitVec out(w);
+    for(std::size_t i = 0; i < w; ++i) {
+      const std::size_t src = i + amt;
+      if(src < w) out._bits[i] = _bits[src];
+    }
+    return out;
+  }
+
+  StrBitVec StrBitVec::ashr(const StrBitVec &rhs) const {
+    // TODO: specify
+    // TODO: ensureSameWidth(rhs, "ashr");
+    const std::size_t w = width();
+    const bool sign = is_negative();
+    bool ge = _rhs_amount_ge_width(rhs, w);
+    if(ge) { return sign ? StrBitVec::ones(w) : StrBitVec::zeros(w); }
+    std::size_t amt = _rhs_amount_mod(rhs, w);
+    StrBitVec out(w);
+    for(std::size_t i = 0; i < w; ++i) {
+      const std::size_t src = i + amt;
+      out._bits[i] = (src < w) ? _bits[src] : sign;
+    }
+    return out;
+  }
+
+  bool StrBitVec::ult(const StrBitVec &rhs) const {
+    // TODO: specify
+    return _compare_unsigned(*this, rhs) < 0;
+  }
+
+  bool StrBitVec::ule(const StrBitVec &rhs) const {
+    // TODO: specify
+    return _compare_unsigned(*this, rhs) <= 0;
+  }
+
+  bool StrBitVec::uge(const StrBitVec &rhs) const {
+    // TODO: specify
+    return _compare_unsigned(*this, rhs) >= 0;
+  }
+
+  bool StrBitVec::ugt(const StrBitVec &rhs) const {
+    // TODO: specify
+    return _compare_unsigned(*this, rhs) > 0;
+  }
+
+  bool StrBitVec::eq(const StrBitVec &rhs) const {
+    // TODO: specify
+    return this->equals(rhs);
+  }
+
+  bool StrBitVec::equals(const StrBitVec &rhs) const {
+    // TODO: specify
+    return _compare_unsigned(*this, rhs) == 0;
+  }
+
+  bool StrBitVec::slt(const StrBitVec &rhs) const {
+    // TODO: specify
+    // TODO: ensureSameWidth(rhs, "slt");
+    const bool sa = is_negative(), sb = rhs.is_negative();
+    if(sa != sb) {
+      return sa; // negative < positive
+    }
+    // Same sign: for negatives, reverse unsigned sense.
+    int cu = _compare_unsigned(*this, rhs);
+    return sa ? (cu > 0) : (cu < 0);
+  }
+
+  bool StrBitVec::sle(const StrBitVec &rhs) const {
+    // TODO: specify
+    return !sgt(rhs);
+  }
+
+  bool StrBitVec::sge(const StrBitVec &rhs) const {
+    // TODO: specify
+    return !slt(rhs);
+  }
+
+  bool StrBitVec::sgt(const StrBitVec &rhs) const {
+    // TODO: specify
+    // TODO: ensureSameWidth(rhs, "sgt");
+    const bool sa = is_negative(), sb = rhs.is_negative();
+    if(sa != sb) return !sa; // positive > negative
+    int cu = _compare_unsigned(*this, rhs);
+    return sa ? (cu < 0) : (cu > 0);
+  }
+
+  StrBitVec StrBitVec::comp(const StrBitVec &rhs) const {
+    // TODO: specify
+    // TODO: ensureSameWidth(rhs, "comp");
+    StrBitVec out(1);
+    out._bits[0] = equals(rhs);
+    return out;
+  }
+
+  bool StrBitVec::nego() const {
+    // TODO: specify
+    return is_most_negative();
+  }
+
+  bool StrBitVec::uaddo(const StrBitVec &rhs) const {
+    // TODO:ensureSameWidth(rhs, "uaddo");
+    // TODO: make common code with uaddo
+    bool carry = false;
+    for(std::size_t i = 0; i < width(); ++i) {
+      const bool a = _bits[i], b = rhs._bits[i];
+      carry = (a & b) | (a & carry) | (b & carry);
+    }
+    return carry;
+  }
+
+  bool StrBitVec::saddo(const StrBitVec &rhs) const {
+    // TODO: specify
+    // TODO: ensureSameWidth(rhs, "saddo");
+    if(width() == 0) return false;
+    StrBitVec sum = add(rhs);
+    const bool sa = is_negative();
+    const bool sb = rhs.is_negative();
+    const bool ss = sum.is_negative();
+    return (sa == sb) && (ss != sa);
+  }
+
+  bool StrBitVec::umulo(const StrBitVec &rhs) const {
+    // TODO: specify
+    // TODO: ensureSameWidth(rhs, "umulo");
+    // TODO: make common code with umulo
+    const std::size_t w = this->width();
+    std::vector<bool> full(2 * w, false);
+    _mul(full, _bits, rhs._bits);
+    // Check high w bits for any 1.
+    for(std::size_t i = w; i < 2 * w; ++i) {
+      if(full[i]) { return true; }
+    }
+    return false;
+  }
+
+  bool StrBitVec::smulo(const StrBitVec &rhs) const {
+    // TODO: specify
+    // TODO: ensureSameWidth(rhs, "smulo");
+    const std::size_t w = width();
+    // Sign-extend both to 2w and multiply (unsigned), then check that the
+    // upper w bits are a sign-extension of the sign bit of the low part.
+    std::vector<bool> a2(2 * w, false), b2(2 * w, false);
+    const bool sa = is_negative(), sb = rhs.is_negative();
+    // copy low
+    for(std::size_t i = 0; i < w; ++i) {
+      a2[i] = _bits[i];
+      b2[i] = rhs._bits[i];
+    }
+    // sign-extend
+    for(std::size_t i = w; i < 2 * w; ++i) {
+      a2[i] = sa;
+      b2[i] = sb;
+    }
+    std::vector<bool> prod(2 * w, false);
+    _mul(prod, a2, b2);
+    const bool sign = prod[w - 1];
+    for(std::size_t i = w; i < 2 * w; ++i) {
+      if(prod[i] != sign) { return true; }
+    }
+    return false;
+  }
+
+  bool StrBitVec::usubo(const StrBitVec &rhs) const {
+    // TODO: specify
+    return ult(rhs);
+  }
+
+  bool StrBitVec::ssubo(const StrBitVec &rhs) const {
+    // TODO: specify
+    // TODO: ensureSameWidth(rhs, "ssubo");
+    StrBitVec diff = sub(rhs);
+    const bool sa = is_negative();
+    const bool sb = rhs.is_negative();
+    const bool sd = diff.is_negative();
+    return (sa != sb) && (sd != sa);
+  }
+
+  bool StrBitVec::sdivo(const StrBitVec &rhs) const {
+    // TODO: specify
+    // TODO: ensureSameWidth(rhs, "sdivo");
+    return is_most_negative() && rhs.is_all_ones();
+  }
+
+  std::string StrBitVec::u_to_int() const {
+    // TODO: specify
+    // Build decimal by scanning from MSB to LSB: s = s*2 + bit
+    std::string s = "0";
+    int msb = _msb_index(_bits);
+    if(msb < 0) { return "0"; }
+    for(int i = msb; i >= 0; --i) {
+      _dec_mul_add(s, 2, 0);
+      if(_bits[static_cast<std::size_t>(i)]) {
+        _dec_mul_add(s, 1, 1); // +1
+      }
+    }
+    _trim_leading_zeros(s);
+    return s;
+  }
+
+  std::string StrBitVec::s_to_int() const {
+    // TODO: specify
+    if(!is_negative()) { return u_to_int(); }
+
+    // magnitude = two's-complement negation
+    StrBitVec mag = this->neg();
+    std::string s = mag.u_to_int();
+    _trim_leading_zeros(s);
+    return "-" + s;
+  }
+
+  bool StrBitVec::_is_decimal_zero(const std::string &s) {
+    for(char c: s) {
+      if(c != '0') { return false; }
+    }
+    return true;
+  }
+
+  int StrBitVec::_div_decimal_by_2(std::string &s) {
+    int carry = 0;
+    std::string out;
+    out.reserve(s.size());
+    for(char ch: s) {
+      if(!std::isdigit(static_cast<unsigned char>(ch))) { throw std::invalid_argument("invalid decimal digit"); }
+      int d = (ch - CodePoint::$0) + 10 * carry;
+      int q = d / 2;
+      carry = d % 2;
+      out.push_back(static_cast<char>(CodePoint::$0 + q));
+    }
+    _trim_leading_zeros(out);
+    if(out.empty()) { out = "0"; }
+    s.swap(out);
+    return carry;
+  }
+
+  void StrBitVec::_trim_leading_zeros(std::string &s) {
+    std::size_t i = 0;
+    while(i + 1 < s.size() && s[i] == CodePoint::$0) { ++i; }
+    if(i) { s.erase(0, i); }
+  }
+
+  // Add a*b into 'acc' (acc has size >= a.size()+b.size())
+  void StrBitVec::_mul(std::vector<bool> &acc, const std::vector<bool> &a, const std::vector<bool> &b) {
+    const std::size_t na = a.size(), nb = b.size();
+    for(std::size_t j = 0; j < nb; ++j) {
+      if(!b[j]) { continue; }
+      bool carry = false;
+      for(std::size_t i = 0; i < na; ++i) {
+        const std::size_t k = i + j;
+        bool sum = acc[k] ^ a[i] ^ carry;
+        carry = (acc[k] & a[i]) | (acc[k] & carry) | (a[i] & carry);
+        acc[k] = sum;
+      }
+      // propagate carry
+      std::size_t k = na + j;
+      while(carry) {
+        bool sum = acc[k] ^ carry;
+        carry = acc[k] & carry;
+        acc[k] = sum;
+        ++k;
+        if(k >= acc.size()) {
+          break; // should not happen if acc large enough
+        }
+      }
+    }
+  }
+
+  // TODO: + rename to ucomp
+  int StrBitVec::_compare_unsigned(const StrBitVec &a, const StrBitVec &b) {
+    // TODO: specify
+    // TODO: a.ensureSameWidth(b, "compare");
+    const std::size_t w = a.width();
+    for(std::size_t i = 0; i < w; ++i) {
+      // scan from MSB to LSB
+      std::size_t idx = w - 1 - i;
+      const bool abit = a._bits[idx], bbit = b._bits[idx];
+      if(abit != bbit) { return abit ? 1 : -1; }
+    }
+    return 0;
+  }
+
+  // Unsigned division: compute quotient q (size w) and remainder r (dynamic).
+  void StrBitVec::_udivrem_bits(const std::vector<bool> &num, const std::vector<bool> &den, std::vector<bool> &q,
+                             std::vector<bool> &r) {
+    const std::size_t w = q.size();
+    r.clear(); // remainder, LSB-first dynamic
+    // Process bits from MSB to LSB.
+    for(std::size_t step = 0; step < w; ++step) {
+      const std::size_t i = w - 1 - step; // current source bit index
+      // r = (r << 1) | num[i]
+      r.insert(r.begin(), false); // left shift by 1 (multiply by 2)
+      if(!r.empty()) { r[0] = num[i]; }
+      _trim_bits(r);
+      // if r >= den then r -= den, q[i] = 1 else 0
+      if(_cmp_arb_unsigned(r, den) >= 0) {
+        _sub_arb_unsigned_in_place(r, den);
+        q[i] = true;
+      } else {
+        q[i] = false;
+      }
+    }
+    _trim_bits(r);
+  }
+
+  // Compare arbitrary-length LSB-first vectors (unsigned).
+  int StrBitVec::_cmp_arb_unsigned(const std::vector<bool> &a, const std::vector<bool> &b) {
+    const int ma = _msb_index(a);
+    const int mb = _msb_index(b);
+    if(ma != mb) return (ma < mb) ? -1 : 1;
+    for(int i = ma; i >= 0; --i) {
+      const bool abit = a[static_cast<std::size_t>(i)];
+      const bool bbit = b[static_cast<std::size_t>(i)];
+      if(abit != bbit) return abit ? 1 : -1;
+    }
+    return 0;
+  }
+
+  // a -= b, assumes a >= b (unsigned), arbitrary-length LSB-first.
+  void StrBitVec::_sub_arb_unsigned_in_place(std::vector<bool> &a, const std::vector<bool> &b) {
+    bool borrow = false;
+    const std::size_t n = std::max(a.size(), b.size());
+    if(a.size() < n) a.resize(n, false);
+    for(std::size_t i = 0; i < n; ++i) {
+      const bool ai = (i < a.size()) ? a[i] : false;
+      const bool bi = (i < b.size()) ? b[i] : false;
+      const bool diff = (ai ^ bi) ^ borrow;
+      borrow = (!ai & bi) | ((!(ai) | bi) & borrow);
+      a[i] = diff;
+    }
+    _trim_bits(a);
+  }
+
+  void StrBitVec::_trim_bits(std::vector<bool> &v) {
+    // Remove leading zeros in MSB direction (but keep at least one 0 if empty).
+    int m = _msb_index(v);
+    if(m < 0) {
+      v.clear();
+    } else if(static_cast<std::size_t>(m + 1) < v.size()) {
+      v.resize(static_cast<std::size_t>(m + 1));
+    }
+  }
+
+  int StrBitVec::_msb_index(const std::vector<bool> &v) {
+    for(int i = static_cast<int>(v.size()) - 1; i >= 0; --i)
+      if(v[static_cast<std::size_t>(i)]) return i;
+    return -1;
+  }
+
+  void StrBitVec::_dec_mul_add(std::string &s, int mul, int add) {
+    int carry = add;
+    for(int i = static_cast<int>(s.size()) - 1; i >= 0; --i) {
+      int d = (s[static_cast<std::size_t>(i)] - CodePoint::$0) * mul + carry;
+      s[static_cast<std::size_t>(i)] = static_cast<char>(CodePoint::$0 + (d % 10));
+      carry = d / 10;
+    }
+    while(carry > 0) {
+      s.insert(s.begin(), static_cast<char>(CodePoint::$0 + (carry % 10)));
+      carry /= 10;
+    }
+  }
+
+  std::size_t StrBitVec::_rhs_amount_mod(const StrBitVec &amt, std::size_t mod) {
+    if(mod == 0) { return 0; }
+    // Horner: ((...((0*2 + bN)*2 + bN-1)... ) % mod)
+    std::size_t r = 0;
+    for(int i = _msb_index(amt._bits); i >= 0; --i) {
+      r = (r * 2) % mod;
+      if(amt._bits[static_cast<std::size_t>(i)]) { r = (r + 1) % mod; }
+    }
+    return r;
+  }
+
+  bool StrBitVec::_rhs_amount_ge_width(const StrBitVec &amt, std::size_t w) {
+    if(w == 0) {
+      return true; // any amount >= 0 when width==0
+    }
+    int ma = _msb_index(amt._bits);
+    if(ma < 0) { return false; }
+    int mw = 0;
+    for(std::size_t tmp = w >> 1; tmp > 0; tmp >>= 1) { ++mw; }
+    if(ma > mw) { return true; }
+    if(ma < mw) { return false; }
+    for(int i = mw; i >= 0; --i) {
+      const bool abit = amt._bits[static_cast<std::size_t>(i)];
+      const bool wbit = ((w >> i) & 1u) != 0;
+      if(abit != wbit) return abit; // true if amt bit is 1 when w bit 0
+    }
+    return true; // equal
+  }
+
+} // namespace btgly

--- a/tests/arith_fuzz_test.cc
+++ b/tests/arith_fuzz_test.cc
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+#include <random>
+#include <string>
+
+#include "btgly/bitvec.hh"
+#include "btgly/strbitvec.hh"
+
+using namespace btgly;
+
+TEST(BitVecArithmeticFuzz, SmallVsStrReference) {
+  std::mt19937_64 rng(12345);
+  std::uniform_int_distribution<int> widthDist(0, 64);
+  for(int i = 0; i < 1000; ++i) {
+    std::size_t w = static_cast<std::size_t>(widthDist(rng));
+    std::uint64_t mask = w == 64 ? ~std::uint64_t{0} : ((std::uint64_t{1} << w) - 1);
+    std::uint64_t a = rng() & mask;
+    std::uint64_t b = rng() & mask;
+
+    BitVec ba = BitVec::from_int(std::to_string(a), w);
+    BitVec bb = BitVec::from_int(std::to_string(b), w);
+    StrBitVec sa = StrBitVec::from_int(std::to_string(a), w);
+    StrBitVec sb = StrBitVec::from_int(std::to_string(b), w);
+
+    BitVec add_res = ba.add(bb);
+    StrBitVec add_ref = sa.add(sb);
+    EXPECT_EQ(add_res.bits(), add_ref.bits());
+
+    BitVec sub_res = ba.sub(bb);
+    StrBitVec sub_ref = sa.sub(sb);
+    EXPECT_EQ(sub_res.bits(), sub_ref.bits());
+
+    BitVec neg_res = ba.neg();
+    StrBitVec neg_ref = sa.neg();
+    EXPECT_EQ(neg_res.bits(), neg_ref.bits());
+
+    EXPECT_EQ(ba.uaddo(bb), sa.uaddo(sb));
+    EXPECT_EQ(ba.usubo(bb), sa.usubo(sb));
+    EXPECT_EQ(ba.saddo(bb), sa.saddo(sb));
+    EXPECT_EQ(ba.ssubo(bb), sa.ssubo(sb));
+    EXPECT_EQ(ba.nego(), sa.nego());
+
+    BitVec mul_res = ba.mul(bb);
+    StrBitVec mul_ref = sa.mul(sb);
+    EXPECT_EQ(mul_res.bits(), mul_ref.bits());
+
+    BitVec udiv_res = ba.udiv(bb);
+    StrBitVec udiv_ref = sa.udiv(sb);
+    EXPECT_EQ(udiv_res.bits(), udiv_ref.bits());
+
+    BitVec urem_res = ba.urem(bb);
+    StrBitVec urem_ref = sa.urem(sb);
+    EXPECT_EQ(urem_res.bits(), urem_ref.bits());
+
+    BitVec sdiv_res = ba.sdiv(bb);
+    StrBitVec sdiv_ref = sa.sdiv(sb);
+    EXPECT_EQ(sdiv_res.bits(), sdiv_ref.bits());
+
+    BitVec srem_res = ba.srem(bb);
+    StrBitVec srem_ref = sa.srem(sb);
+    EXPECT_EQ(srem_res.bits(), srem_ref.bits());
+
+    BitVec smod_res = ba.smod(bb);
+    StrBitVec smod_ref = sa.smod(sb);
+    EXPECT_EQ(smod_res.bits(), smod_ref.bits());
+
+    EXPECT_EQ(ba.umulo(bb), sa.umulo(sb));
+    EXPECT_EQ(ba.sdivo(bb), sa.sdivo(sb));
+  }
+}
+

--- a/tests/strbitvec_test.cc
+++ b/tests/strbitvec_test.cc
@@ -1,0 +1,617 @@
+#include <gtest/gtest.h>
+#include "btgly/strbitvec.hh"
+
+using namespace btgly;
+
+TEST(StrBitVecConstruction, Basics) {
+  StrBitVec empty(4);
+  EXPECT_EQ(empty.width(), 4u);
+  EXPECT_TRUE(empty.is_zero());
+
+  StrBitVec ones = StrBitVec::ones(4);
+  EXPECT_TRUE(ones.is_all_ones());
+
+  StrBitVec zeros = StrBitVec::zeros(4);
+  EXPECT_TRUE(zeros.is_zero());
+
+  StrBitVec fromBoolTrue(true, 3);
+  EXPECT_TRUE(fromBoolTrue.is_all_ones());
+
+  StrBitVec fromBoolFalse(false, 2);
+  EXPECT_TRUE(fromBoolFalse.is_zero());
+
+  StrBitVec neg = StrBitVec::from_int("-8", 4);
+  EXPECT_TRUE(neg.is_negative());
+  EXPECT_TRUE(neg.is_most_negative());
+  EXPECT_EQ(neg.s_to_int(), "-8");
+}
+
+TEST(StrBitVecManipulation, BasicOps) {
+  StrBitVec a = StrBitVec::from_int("0b1010", 4);
+  StrBitVec b = StrBitVec::from_int("0b1100", 4);
+  StrBitVec cat = a.concat(b);
+  EXPECT_EQ(cat.u_to_int(), "172");
+
+  StrBitVec ext = cat.extract(5, 2);
+  EXPECT_EQ(ext.u_to_int(), "11");
+
+  StrBitVec rep = StrBitVec::from_int("0b10", 2).repeat(3);
+  EXPECT_EQ(rep.u_to_int(), "42");
+
+  StrBitVec se = StrBitVec::from_int("-3", 3).sign_extend(2);
+  EXPECT_EQ(se.s_to_int(), "-3");
+
+  StrBitVec ze = StrBitVec::from_int("0b101", 3).zero_extend(2);
+  EXPECT_EQ(ze.u_to_int(), "5");
+
+  StrBitVec rl = StrBitVec::from_int("0b1001", 4).rotate_left(1);
+  EXPECT_EQ(rl.u_to_int(), "3");
+
+  StrBitVec rr = StrBitVec::from_int("0b1001", 4).rotate_right(2);
+  EXPECT_EQ(rr.u_to_int(), "6");
+
+  StrBitVec n = a.$not();
+  EXPECT_EQ(n.u_to_int(), "5");
+
+  StrBitVec aand = a.$and(b);
+  EXPECT_EQ(aand.u_to_int(), "8");
+
+  StrBitVec oor = a.$or(b);
+  EXPECT_EQ(oor.u_to_int(), "14");
+
+  StrBitVec xxor = a.$xor(b);
+  EXPECT_EQ(xxor.u_to_int(), "6");
+
+  StrBitVec anand = a.nand(b);
+  EXPECT_EQ(anand.u_to_int(), "7");
+
+  StrBitVec anor = a.nor(b);
+  EXPECT_EQ(anor.u_to_int(), "1");
+
+  StrBitVec axnor = a.xnor(b);
+  EXPECT_EQ(axnor.u_to_int(), "9");
+
+  EXPECT_TRUE(StrBitVec::ones(3).redand());
+  EXPECT_FALSE(StrBitVec::from_int("0b101", 3).redand());
+  EXPECT_TRUE(StrBitVec::from_int("0b100", 3).redor());
+  EXPECT_FALSE(StrBitVec::zeros(3).redor());
+}
+
+TEST(StrBitVecArithmetic, Operations) {
+  StrBitVec two = StrBitVec::from_int("2", 3);
+  EXPECT_EQ(two.neg().s_to_int(), "-2");
+
+  StrBitVec add = StrBitVec::from_int("3", 3).add(StrBitVec::from_int("1", 3));
+  EXPECT_EQ(add.u_to_int(), "4");
+
+  StrBitVec sub = StrBitVec::from_int("3", 3).sub(StrBitVec::from_int("1", 3));
+  EXPECT_EQ(sub.u_to_int(), "2");
+
+  StrBitVec mul = StrBitVec::from_int("3", 4).mul(StrBitVec::from_int("2", 4));
+  EXPECT_EQ(mul.u_to_int(), "6");
+
+  StrBitVec udiv = StrBitVec::from_int("6", 4).udiv(StrBitVec::from_int("2", 4));
+  EXPECT_EQ(udiv.u_to_int(), "3");
+
+  StrBitVec urem = StrBitVec::from_int("6", 4).urem(StrBitVec::from_int("4", 4));
+  EXPECT_EQ(urem.u_to_int(), "2");
+
+  StrBitVec sdiv = StrBitVec::from_int("-6", 4).sdiv(StrBitVec::from_int("2", 4));
+  EXPECT_EQ(sdiv.s_to_int(), "-3");
+
+  StrBitVec srem = StrBitVec::from_int("-7", 4).srem(StrBitVec::from_int("4", 4));
+  EXPECT_EQ(srem.s_to_int(), "-3");
+
+  StrBitVec smod = StrBitVec::from_int("-7", 4).smod(StrBitVec::from_int("4", 4));
+  EXPECT_EQ(smod.u_to_int(), "1");
+
+  StrBitVec shl = StrBitVec::from_int("3", 4).shl(StrBitVec::from_int("1", 4));
+  EXPECT_EQ(shl.u_to_int(), "6");
+
+  StrBitVec lshr = StrBitVec::from_int("8", 4).lshr(StrBitVec::from_int("1", 4));
+  EXPECT_EQ(lshr.u_to_int(), "4");
+
+  StrBitVec ashr = StrBitVec::from_int("-4", 4).ashr(StrBitVec::from_int("1", 4));
+  EXPECT_EQ(ashr.s_to_int(), "-2");
+}
+
+TEST(StrBitVecComparison, Relations) {
+  StrBitVec three = StrBitVec::from_int("3", 4);
+  StrBitVec five = StrBitVec::from_int("5", 4);
+  EXPECT_TRUE(three.ult(five));
+  EXPECT_TRUE(three.ule(three));
+  EXPECT_TRUE(five.uge(three));
+  EXPECT_TRUE(five.ugt(three));
+  EXPECT_TRUE(three.eq(StrBitVec::from_int("3", 4)));
+  EXPECT_TRUE(three.equals(StrBitVec::from_int("3", 4)));
+
+  StrBitVec minus2 = StrBitVec::from_int("-2", 4);
+  StrBitVec one = StrBitVec::from_int("1", 4);
+  EXPECT_TRUE(minus2.slt(one));
+  EXPECT_TRUE(minus2.sle(minus2));
+  EXPECT_TRUE(one.sge(minus2));
+  EXPECT_TRUE(one.sgt(minus2));
+
+  StrBitVec compEq = three.comp(StrBitVec::from_int("3", 4));
+  EXPECT_EQ(compEq.u_to_int(), "1");
+  StrBitVec compNe = three.comp(five);
+  EXPECT_EQ(compNe.u_to_int(), "0");
+}
+
+TEST(StrBitVecOverflow, Detection) {
+  StrBitVec min = StrBitVec::from_int("-8", 4);
+  EXPECT_TRUE(min.nego());
+
+  StrBitVec uadd_lhs = StrBitVec::from_int("15", 4);
+  StrBitVec uadd_rhs = StrBitVec::from_int("1", 4);
+  EXPECT_TRUE(uadd_lhs.uaddo(uadd_rhs));
+
+  StrBitVec sadd_lhs = StrBitVec::from_int("4", 4);
+  StrBitVec sadd_rhs = StrBitVec::from_int("5", 4);
+  EXPECT_TRUE(sadd_lhs.saddo(sadd_rhs));
+
+  StrBitVec umul_lhs = StrBitVec::from_int("8", 4);
+  StrBitVec umul_rhs = StrBitVec::from_int("2", 4);
+  EXPECT_TRUE(umul_lhs.umulo(umul_rhs));
+
+  StrBitVec smul_lhs = StrBitVec::from_int("4", 4);
+  StrBitVec smul_rhs = StrBitVec::from_int("4", 4);
+  EXPECT_TRUE(smul_lhs.smulo(smul_rhs));
+
+  StrBitVec usub_lhs = StrBitVec::from_int("3", 4);
+  StrBitVec usub_rhs = StrBitVec::from_int("5", 4);
+  EXPECT_TRUE(usub_lhs.usubo(usub_rhs));
+
+  StrBitVec ssub_lhs = StrBitVec::from_int("7", 4);
+  StrBitVec ssub_rhs = StrBitVec::from_int("-2", 4);
+  EXPECT_TRUE(ssub_lhs.ssubo(ssub_rhs));
+
+  StrBitVec sdiv_lhs = StrBitVec::from_int("-8", 4);
+  StrBitVec sdiv_rhs = StrBitVec::from_int("-1", 4);
+  EXPECT_TRUE(sdiv_lhs.sdivo(sdiv_rhs));
+}
+
+TEST(StrBitVecConversion, ToInt) {
+  StrBitVec u = StrBitVec::from_int("42", 8);
+  EXPECT_EQ(u.u_to_int(), "42");
+  StrBitVec s = StrBitVec::from_int("-5", 8);
+  EXPECT_EQ(s.s_to_int(), "-5");
+}
+
+TEST(StrBitVecParsing, VariousBasesAndErrors) {
+  StrBitVec hex = StrBitVec::from_int("0x1f", 8);
+  EXPECT_EQ(hex.u_to_int(), "31");
+  StrBitVec oct = StrBitVec::from_int("0o17", 8);
+  EXPECT_EQ(oct.u_to_int(), "15");
+  StrBitVec binUpper = StrBitVec::from_int("0B101", 3);
+  EXPECT_EQ(binUpper.u_to_int(), "5");
+  EXPECT_THROW(StrBitVec::from_int("0b102", 8), std::invalid_argument);
+  EXPECT_THROW(StrBitVec::from_int("0o8", 4), std::invalid_argument);
+  EXPECT_THROW(StrBitVec::from_int("0xG", 4), std::invalid_argument);
+}
+
+TEST(StrBitVecShiftRotate, LargeAmounts) {
+  StrBitVec v = StrBitVec::from_int("0b1001", 4);
+  EXPECT_EQ(v.rotate_left(4).u_to_int(), "9");
+  EXPECT_EQ(v.rotate_right(6).u_to_int(), "6");
+  StrBitVec shl = StrBitVec::from_int("3", 4).shl(StrBitVec::from_int("4", 4));
+  EXPECT_TRUE(shl.is_zero());
+  StrBitVec lshr = StrBitVec::from_int("8", 4).lshr(StrBitVec::from_int("5", 4));
+  EXPECT_TRUE(lshr.is_zero());
+  StrBitVec ashrNeg = StrBitVec::from_int("-4", 4).ashr(StrBitVec::from_int("5", 4));
+  EXPECT_EQ(ashrNeg.s_to_int(), "-1");
+  StrBitVec ashrPos = StrBitVec::from_int("4", 4).ashr(StrBitVec::from_int("5", 4));
+  EXPECT_TRUE(ashrPos.is_zero());
+}
+
+TEST(StrBitVecDivision, DivisionByZeroAndOverflow) {
+  StrBitVec v = StrBitVec::from_int("5", 4);
+  EXPECT_EQ(v.udiv(StrBitVec::zeros(4)).u_to_int(), "15");
+  EXPECT_EQ(v.urem(StrBitVec::zeros(4)).u_to_int(), "5");
+  StrBitVec neg = StrBitVec::from_int("-3", 4);
+  EXPECT_EQ(neg.sdiv(StrBitVec::zeros(4)).s_to_int(), "-1");
+  EXPECT_EQ(neg.srem(StrBitVec::zeros(4)).s_to_int(), "-3");
+  EXPECT_EQ(neg.smod(StrBitVec::zeros(4)).s_to_int(), "-3");
+  StrBitVec min = StrBitVec::from_int("-8", 4);
+  StrBitVec minusOne = StrBitVec::from_int("-1", 4);
+  StrBitVec sdivRes = min.sdiv(minusOne);
+  EXPECT_EQ(sdivRes.s_to_int(), "-8");
+  StrBitVec sremRes = min.srem(minusOne);
+  EXPECT_TRUE(sremRes.is_zero());
+  StrBitVec smodRes = min.smod(minusOne);
+  EXPECT_TRUE(smodRes.is_zero());
+}
+
+TEST(StrBitVecMisc, RepeatExtractAndOverflowFalse) {
+  StrBitVec v = StrBitVec::from_int("1", 1);
+  StrBitVec r0 = v.repeat(0);
+  EXPECT_EQ(r0.width(), 0u);
+  StrBitVec eSrc = StrBitVec::from_int("0b101", 3);
+  EXPECT_THROW(eSrc.extract(1, 2), std::invalid_argument);
+  EXPECT_THROW(eSrc.extract(3, 1), std::out_of_range);
+  StrBitVec uaddLhs = StrBitVec::from_int("3", 4);
+  StrBitVec uaddRhs = StrBitVec::from_int("1", 4);
+  EXPECT_FALSE(uaddLhs.uaddo(uaddRhs));
+  StrBitVec saddLhs = StrBitVec::from_int("1", 4);
+  StrBitVec saddRhs = StrBitVec::from_int("1", 4);
+  EXPECT_FALSE(saddLhs.saddo(saddRhs));
+  StrBitVec umulLhs = StrBitVec::from_int("2", 4);
+  StrBitVec umulRhs = StrBitVec::from_int("3", 4);
+  EXPECT_FALSE(umulLhs.umulo(umulRhs));
+  StrBitVec smulLhs = StrBitVec::from_int("2", 4);
+  StrBitVec smulRhs = StrBitVec::from_int("2", 4);
+  EXPECT_FALSE(smulLhs.smulo(smulRhs));
+  StrBitVec usubLhs = StrBitVec::from_int("5", 4);
+  StrBitVec usubRhs = StrBitVec::from_int("3", 4);
+  EXPECT_FALSE(usubLhs.usubo(usubRhs));
+  StrBitVec ssubLhs = StrBitVec::from_int("2", 4);
+  StrBitVec ssubRhs = StrBitVec::from_int("1", 4);
+  EXPECT_FALSE(ssubLhs.ssubo(ssubRhs));
+  StrBitVec sdivoLhs = StrBitVec::from_int("4", 4);
+  StrBitVec sdivoRhs = StrBitVec::from_int("2", 4);
+  EXPECT_FALSE(sdivoLhs.sdivo(sdivoRhs));
+}
+
+TEST(StrBitVecParsing, SignPrefixesAndLargeDecimal) {
+  StrBitVec plus = StrBitVec::from_int("+42", 8);
+  EXPECT_EQ(plus.u_to_int(), "42");
+  StrBitVec negBin = StrBitVec::from_int("-0b1010", 5);
+  EXPECT_EQ(negBin.s_to_int(), "-10");
+  StrBitVec negHex = StrBitVec::from_int("-0x1F", 8);
+  EXPECT_EQ(negHex.s_to_int(), "-31");
+  StrBitVec bigDec = StrBitVec::from_int("12345678901234567890", 64);
+  EXPECT_EQ(bigDec.u_to_int(), "12345678901234567890");
+}
+
+TEST(StrBitVecShiftRotate, ZeroAmountsAndZeroWidth) {
+  StrBitVec v = StrBitVec::from_int("0b1010", 4);
+  StrBitVec shl0 = v.shl(StrBitVec::zeros(4));
+  EXPECT_EQ(shl0.u_to_int(), "10");
+  StrBitVec lshr0 = v.lshr(StrBitVec::zeros(4));
+  EXPECT_EQ(lshr0.u_to_int(), "10");
+  StrBitVec ashr0 = StrBitVec::from_int("-4", 4).ashr(StrBitVec::zeros(4));
+  EXPECT_EQ(ashr0.s_to_int(), "-4");
+  StrBitVec zeroW = StrBitVec::zeros(0);
+  StrBitVec shlZW = zeroW.shl(StrBitVec::from_int("1", 1));
+  EXPECT_EQ(shlZW.width(), 0u);
+  StrBitVec lshrZW = zeroW.lshr(StrBitVec::from_int("1", 1));
+  EXPECT_EQ(lshrZW.width(), 0u);
+}
+
+TEST(StrBitVecSignedArith, MixedSigns) {
+  StrBitVec pos = StrBitVec::from_int("6", 4);
+  StrBitVec neg = StrBitVec::from_int("-2", 4);
+  StrBitVec sdiv = pos.sdiv(neg);
+  EXPECT_EQ(sdiv.s_to_int(), "-3");
+  StrBitVec srem = pos.srem(neg);
+  EXPECT_EQ(srem.s_to_int(), "0");
+  StrBitVec smod = StrBitVec::from_int("-7", 4).smod(StrBitVec::from_int("3", 4));
+  EXPECT_EQ(smod.s_to_int(), "2");
+}
+
+// ---------- Small helpers ----------
+static StrBitVec mk_dec(std::size_t w, unsigned long long v) { return StrBitVec::from_int(std::to_string(v), w); }
+
+static StrBitVec mk_hex(std::size_t w, const std::string &hex_wo_prefix) {
+  return StrBitVec::from_int(std::string("0x") + hex_wo_prefix, w);
+}
+
+static StrBitVec mk_bin(std::size_t w, const std::string &bits_wo_prefix) {
+  return StrBitVec::from_int(std::string("0b") + bits_wo_prefix, w);
+}
+
+static StrBitVec bv_min(std::size_t w) { // most-negative: 1000...0
+  if(w == 0) return StrBitVec::zeros(0);
+  // Start with width-1 zero-extend of 1 -> 00..001, then rotate left by w-1
+  StrBitVec one1 = mk_dec(1, 1);
+  StrBitVec msb = one1.zero_extend(w - 1).rotate_left(w - 1);
+  return msb;
+}
+
+static StrBitVec bv_smax(std::size_t w) { // signed max: 0111...1
+  if(w == 0) return StrBitVec::zeros(0);
+  StrBitVec all1 = StrBitVec::ones(w);
+  StrBitVec one = mk_dec(w, 1);
+  return all1.lshr(one); // logical >> 1 turns 111..1 into 0111..1
+}
+
+static StrBitVec bv_neg1(std::size_t w) { return StrBitVec::ones(w); }
+static StrBitVec bv_zero(std::size_t w) { return StrBitVec::zeros(w); }
+
+static void expect_bveq(const StrBitVec &a, const StrBitVec &b) {
+  ASSERT_EQ(a.width(), b.width()) << "Width mismatch";
+  EXPECT_TRUE(a.equals(b)) << "u(a)=" << a.u_to_int() << ", u(b)=" << b.u_to_int();
+  EXPECT_TRUE(a.eq(b));
+}
+
+// ---------- Parameterized by width ----------
+class StrBitVecWidthSuite: public ::testing::TestWithParam<size_t> {};
+
+INSTANTIATE_TEST_SUITE_P(AllWidths, StrBitVecWidthSuite,
+                         ::testing::Values(0u, 1u, 5u, 8u, 13u, 16u, 25u, 32u, 55u, 64u, 99u, 128u));
+
+TEST_P(StrBitVecWidthSuite, ConstructorsAndProperties) {
+  const size_t w = GetParam();
+  StrBitVec raw(w); // just exercise the ctor; content unspecified
+  EXPECT_EQ(raw.width(), w);
+
+  StrBitVec z = StrBitVec::zeros(w);
+  StrBitVec o = StrBitVec::ones(w);
+
+  EXPECT_EQ(z.width(), w);
+  EXPECT_EQ(o.width(), w);
+  EXPECT_TRUE(z.is_zero());
+  if(w > 0) {
+    EXPECT_FALSE(z.is_all_ones());
+    EXPECT_FALSE(o.is_zero());
+  }
+  EXPECT_TRUE(o.is_all_ones());
+
+  if(w > 0) {
+    EXPECT_FALSE(z.is_negative());
+    EXPECT_TRUE(bv_neg1(w).is_negative());
+    EXPECT_TRUE(bv_min(w).is_most_negative());
+    EXPECT_EQ(bv_min(w).is_negative(), true);
+  }
+
+  // bits()[0] should be LSB
+  StrBitVec five = mk_dec(w, 5); // ..0101
+  if(w >= 3) {
+    EXPECT_TRUE(five.bits()[0]);
+    EXPECT_FALSE(five.bits()[1]);
+    EXPECT_TRUE(five.bits()[2]);
+  } else if(w == 2) {
+    EXPECT_TRUE(five.bits()[0]);
+    EXPECT_FALSE(five.bits()[1]);
+  } else if(w == 1) {
+    EXPECT_TRUE(five.bits()[0]);
+  }
+}
+
+TEST_P(StrBitVecWidthSuite, FromIntParsingAndModulo) {
+  const size_t w = GetParam();
+  // Hex, bin, oct and decimal; ensure truncation modulo 2^w
+  StrBitVec a = StrBitVec::from_int("0xff", w);
+  StrBitVec b = StrBitVec::from_int("255", w);
+  expect_bveq(a, b);
+
+  StrBitVec c = StrBitVec::from_int("0o77", w); // 63
+  StrBitVec d = mk_dec(w, 63ull);
+  expect_bveq(c, d);
+
+  // Truncation: add one bit beyond width
+  std::string big_hex = (w == 0) ? "0" : "1" + std::string((w + 3) / 4, '0');
+  StrBitVec e = mk_hex(w, big_hex); // 1 << (4*((w+3)/4)) truncated to w
+  (void) e;                      // constructed; core correctness exercised elsewhere
+}
+
+TEST_P(StrBitVecWidthSuite, ConcatExtractRepeat) {
+  const size_t w = GetParam();
+  // Build two pieces whose widths add up to 2*w (works even for w==1)
+  StrBitVec hi = mk_dec(w, 0xAAAAAAAAull); // truncated to w
+  StrBitVec lo = mk_dec(w, 0x55555555ull);
+  StrBitVec both = hi.concat(lo);
+  EXPECT_EQ(both.width(), w + w);
+
+  // Extract back low and high parts
+  if(w > 0) {
+    StrBitVec lo_x = both.extract(w - 1, 0);
+    StrBitVec hi_x = both.extract(2 * w - 1, w);
+    expect_bveq(lo_x, lo);
+    expect_bveq(hi_x, hi);
+  }
+
+  // Repeat basic shape
+  StrBitVec base = mk_bin(3, "101");
+  StrBitVec r0 = base.repeat(0);
+  EXPECT_EQ(r0.width(), 0u);
+  EXPECT_TRUE(r0.redand());
+  EXPECT_FALSE(r0.redor());
+  StrBitVec r3 = base.repeat(3); // 101101101
+  EXPECT_EQ(r3.width(), 9u);
+  // spot-check a couple of bits
+  EXPECT_TRUE(r3.bits()[0]); // ...1
+  EXPECT_TRUE(r3.bits()[2]); // ...101
+}
+
+TEST_P(StrBitVecWidthSuite, RotatesAndShifts) {
+  const size_t w = GetParam();
+  if(w == 0) GTEST_SKIP();
+
+  StrBitVec v = (w >= 4) ? mk_bin(4, "1001").zero_extend(w - 4) : mk_bin(w, "1");
+  // rotate inverse
+  for(auto k: {0ull, 1ull, 3ull, (unsigned long long) w, (unsigned long long) (w + 7)}) {
+    StrBitVec rl = v.rotate_left(k);
+    StrBitVec back = rl.rotate_right(k);
+    expect_bveq(back, v);
+  }
+  // rotate by w+1 == rotate by 1
+  expect_bveq(v.rotate_left(w + 1), v.rotate_left(1));
+  expect_bveq(v.rotate_right(w + 1), v.rotate_right(1));
+
+  // Logical shifts: shift >= width -> zeros
+  StrBitVec amt_ge = mk_dec(w, w);
+  StrBitVec zeros = bv_zero(w);
+  expect_bveq(v.shl(amt_ge), zeros);
+  expect_bveq(v.lshr(amt_ge), zeros);
+
+  // Arithmetic shift: fill with sign bit
+  StrBitVec neg = bv_min(w);  // MSB=1
+  StrBitVec pos = bv_zero(w); // MSB=0
+  StrBitVec one = mk_dec(w, 1);
+  StrBitVec neg_shift1 = neg.ashr(one); // 1000..0 >>a 1 == 1100..0 (sign bit fill)
+  EXPECT_TRUE(neg_shift1.is_negative());
+  expect_bveq(pos.ashr(amt_ge), pos); // all zeros stays zeros
+  // For negative, ashr >= width -> all ones
+  if(w > 0) { expect_bveq(neg.ashr(amt_ge), bv_neg1(w)); }
+}
+
+TEST_P(StrBitVecWidthSuite, BitwiseOpsAndReductions) {
+  const size_t w = GetParam();
+  if(w <= 1) GTEST_SKIP();
+  StrBitVec a = mk_dec(w, 0xF0F0F0F0ull);
+  StrBitVec b = mk_dec(w, 0x0FF00FF0ull);
+
+  StrBitVec nota = a.$not();
+  expect_bveq(nota.$not(), a);
+
+  expect_bveq(a.nand(b), a.$and(b).$not());
+  expect_bveq(a.nor(b), a.$or(b).$not());
+  expect_bveq(a.xnor(b), a.$xor(b).$not());
+
+  // redand/redor
+  EXPECT_TRUE(bv_neg1(w).redand());
+  EXPECT_FALSE(bv_zero(w).redand());
+  EXPECT_TRUE(a.redor() || b.redor());
+  EXPECT_FALSE(bv_zero(w).redor());
+}
+
+TEST_P(StrBitVecWidthSuite, ArithmeticModuloAndOverflowFlags) {
+  const size_t w = GetParam();
+  if(w <= 1) GTEST_SKIP();
+
+  StrBitVec x = mk_dec(w, 1234567ull);
+  StrBitVec y = mk_dec(w, 891011ull);
+
+  // x + (-x) == 0 (mod 2^w)
+  expect_bveq(x.add(x.neg()), bv_zero(w));
+
+  // (x + y) - y == x
+  expect_bveq(x.add(y).sub(y), x);
+
+  // ones + 1 wraps to 0, and uaddo detects it
+  StrBitVec one = mk_dec(w, 1);
+  EXPECT_TRUE(StrBitVec::ones(w).uaddo(one));
+  expect_bveq(StrBitVec::ones(w).add(one), bv_zero(w));
+
+  // usubo: 0 - 1 borrows
+  EXPECT_TRUE(bv_zero(w).usubo(one));
+
+  // saddo: smax + 1 overflows
+  EXPECT_TRUE(bv_smax(w).saddo(one));
+
+  // ssubo: smax - (-1) overflows
+  EXPECT_TRUE(bv_smax(w).ssubo(bv_neg1(w)));
+
+  // sdivo: min / -1
+  EXPECT_TRUE(bv_min(w).sdivo(bv_neg1(w)));
+
+  // negation overflow predicate == is_most_negative
+  EXPECT_EQ(bv_min(w).nego(), true);
+  EXPECT_EQ(x.nego(), false);
+
+  // Multiplication identities
+  expect_bveq(x.mul(one), x);
+  expect_bveq(x.mul(bv_zero(w)), bv_zero(w));
+
+  // Unsigned multiplication overflow example when possible (w>=2)
+  if(w >= 2) {
+    StrBitVec two = mk_dec(w, 2);
+    EXPECT_TRUE(bv_min(w).umulo(two));
+    expect_bveq(bv_min(w).mul(two), bv_zero(w)); // 1<< (w-1) * 2 == 0 mod 2^w
+  }
+}
+
+TEST_P(StrBitVecWidthSuite, DivRemAndModSemantics) {
+  const size_t w = GetParam();
+  if(w == 0) GTEST_SKIP();
+  StrBitVec zero = bv_zero(w);
+  StrBitVec all1 = bv_neg1(w);
+
+  StrBitVec a = mk_dec(w, 12345);
+  StrBitVec b = mk_dec(w, 234);
+
+  // Division by zero cases
+  expect_bveq(a.udiv(zero), all1);
+  expect_bveq(a.urem(zero), a);
+  expect_bveq(a.sdiv(zero), all1); // -1
+  expect_bveq(a.srem(zero), a);
+  expect_bveq(a.smod(zero), a);
+
+  // Overflow (min / -1)
+  expect_bveq(bv_min(w).sdiv(all1), bv_min(w));
+  expect_bveq(bv_min(w).srem(all1), bv_zero(w));
+  expect_bveq(bv_min(w).smod(all1), bv_zero(w));
+
+  // udiv/urem relation: a = q*b + r, with r < b (when b != 0)
+  if(!b.is_zero()) {
+    StrBitVec q = a.udiv(b);
+    StrBitVec r = a.urem(b);
+    expect_bveq(q.mul(b).add(r), a);
+    EXPECT_TRUE(r.ult(b));
+  }
+}
+
+TEST_P(StrBitVecWidthSuite, ComparisonsAndComp) {
+  const size_t w = GetParam();
+  if(w <= 1) GTEST_SKIP();
+
+  StrBitVec z = bv_zero(w);
+  StrBitVec mn = bv_min(w);
+  StrBitVec mxs = bv_smax(w);
+  StrBitVec m1 = bv_neg1(w); // -1
+
+  // Unsigned
+  EXPECT_TRUE(z.ult(m1));
+  EXPECT_TRUE(m1.ugt(z));
+  EXPECT_TRUE(z.ule(z));
+  EXPECT_TRUE(m1.uge(m1));
+
+  // Signed
+  EXPECT_TRUE(mn.slt(z));
+  EXPECT_TRUE(mxs.sgt(z));
+  EXPECT_TRUE(m1.sle(z));
+  EXPECT_TRUE(mn.sle(mn));
+
+  // eq vs equals
+  EXPECT_TRUE(m1.eq(bv_neg1(w)));
+  EXPECT_TRUE(m1.equals(bv_neg1(w)));
+  EXPECT_EQ(m1.eq(z), m1.equals(z));
+
+  // bvcomp (1-bit result)
+  StrBitVec c1 = z.comp(z);
+  StrBitVec c0 = z.comp(m1);
+  EXPECT_EQ(c1.width(), 1u);
+  EXPECT_EQ(c0.width(), 1u);
+  EXPECT_TRUE(c1.eq(StrBitVec::from_int("1", 1)));
+  EXPECT_TRUE(c0.eq(StrBitVec::from_int("0", 1)));
+}
+
+TEST_P(StrBitVecWidthSuite, ToIntStringsSigns) {
+  const size_t w = GetParam();
+  if(w == 0) GTEST_SKIP();
+
+  StrBitVec z = bv_zero(w);
+  StrBitVec m1 = bv_neg1(w);
+  EXPECT_EQ(z.u_to_int(), std::string("0"));
+  EXPECT_EQ(z.s_to_int(), std::string("0"));
+  // -1 signed string must start with '-'
+  std::string sm1 = m1.s_to_int();
+  ASSERT_FALSE(sm1.empty());
+  EXPECT_EQ(sm1[0], '-');
+
+  // For small widths (<=16), check a few exact values
+  if(w <= 16) {
+    StrBitVec v = mk_dec(w, 42);
+    if(w >= 6) {
+      EXPECT_EQ(v.u_to_int(), std::string("42"));
+      if(!v.is_negative()) EXPECT_EQ(v.s_to_int(), std::string("42"));
+    }
+
+    StrBitVec neg = bv_min(w); // most-negative
+    std::string sneg = neg.s_to_int();
+    ASSERT_FALSE(sneg.empty());
+    EXPECT_EQ(sneg[0], '-');
+  }
+}
+
+// A small non-parameterized smoke test for $and/$or/$xor with width==1 edge cases
+TEST(StrBitVecEdgeCases, WidthOneBasics) {
+  const size_t w = 1;
+  StrBitVec zero = bv_zero(w);
+  StrBitVec one = mk_dec(w, 1);
+  expect_bveq(one.$and(one), one);
+  expect_bveq(one.$or(zero), one);
+  expect_bveq(one.$xor(one), zero);
+  EXPECT_TRUE(one.is_negative()); // in 1-bit two's complement, 1 == -1
+}

--- a/tests/width_property_test.cc
+++ b/tests/width_property_test.cc
@@ -1,0 +1,95 @@
+#include <gtest/gtest.h>
+#include <random>
+#include <string>
+
+#include "btgly/bitvec.hh"
+
+using namespace btgly;
+
+namespace {
+
+std::string random_bits(std::size_t w, std::mt19937_64 &rng) {
+  std::string s("0b");
+  for(std::size_t i = 0; i < w; ++i) {
+    s.push_back((rng() & 1) ? '1' : '0');
+  }
+  return s;
+}
+
+BitVec force_zero_large(const BitVec &v) {
+  return v.zero_extend(65);
+}
+
+BitVec force_sign_large(const BitVec &v) {
+  return v.sign_extend(65);
+}
+
+BitVec trunc(const BitVec &v, std::size_t w) {
+  return w == 0 ? BitVec::zeros(0) : v.extract(w - 1, 0);
+}
+
+} // namespace
+
+TEST(BitVecWidthProperty, SmallVsForcedLarge) {
+  std::vector<std::size_t> widths = {1, 5, 8, 13, 16, 25, 32, 55, 64, 99, 128};
+  std::mt19937_64 rng(123456);
+
+  for(std::size_t w : widths) {
+    for(int iter = 0; iter < 50; ++iter) {
+      BitVec a = BitVec::from_int(random_bits(w, rng), w);
+      BitVec b = BitVec::from_int(random_bits(w, rng), w);
+
+      BitVec az = force_zero_large(a);
+      BitVec bz = force_zero_large(b);
+      BitVec as = force_sign_large(a);
+      BitVec bs = force_sign_large(b);
+
+      // arithmetic
+      EXPECT_EQ(a.add(b).bits(), trunc(az.add(bz), w).bits());
+      EXPECT_EQ(a.sub(b).bits(), trunc(az.sub(bz), w).bits());
+      EXPECT_EQ(a.mul(b).bits(), trunc(az.mul(bz), w).bits());
+      EXPECT_EQ(a.neg().bits(), trunc(as.neg(), w).bits());
+      EXPECT_EQ(a.udiv(b).bits(), trunc(az.udiv(bz), w).bits());
+      EXPECT_EQ(a.urem(b).bits(), trunc(az.urem(bz), w).bits());
+      EXPECT_EQ(a.sdiv(b).bits(), trunc(as.sdiv(bs), w).bits());
+      EXPECT_EQ(a.srem(b).bits(), trunc(as.srem(bs), w).bits());
+      EXPECT_EQ(a.smod(b).bits(), trunc(as.smod(bs), w).bits());
+
+      // bitwise
+      EXPECT_EQ(a.$not().bits(), trunc(az.$not(), w).bits());
+      EXPECT_EQ(a.$and(b).bits(), trunc(az.$and(bz), w).bits());
+      EXPECT_EQ(a.$or(b).bits(), trunc(az.$or(bz), w).bits());
+      EXPECT_EQ(a.$xor(b).bits(), trunc(az.$xor(bz), w).bits());
+      EXPECT_EQ(a.nand(b).bits(), trunc(az.nand(bz), w).bits());
+      EXPECT_EQ(a.nor(b).bits(), trunc(az.nor(bz), w).bits());
+      EXPECT_EQ(a.xnor(b).bits(), trunc(az.xnor(bz), w).bits());
+
+      // shifts
+      std::size_t sh = w == 0 ? 0 : static_cast<std::size_t>(rng() % w);
+      BitVec shv = BitVec::from_int(std::to_string(sh), w);
+      BitVec shz = force_zero_large(shv);
+      EXPECT_EQ(a.shl(shv).bits(), trunc(az.shl(shz), w).bits());
+      EXPECT_EQ(a.lshr(shv).bits(), trunc(az.lshr(shz), w).bits());
+      EXPECT_EQ(a.ashr(shv).bits(), trunc(as.ashr(shz), w).bits());
+
+      // Rotations are covered elsewhere; width extension alters semantics, so
+      // they are omitted from the small-vs-large comparison here.
+
+      // comparisons
+      EXPECT_EQ(a.eq(b), az.eq(bz));
+      EXPECT_EQ(a.equals(b), az.equals(bz));
+      EXPECT_EQ(a.ult(b), az.ult(bz));
+      EXPECT_EQ(a.ule(b), az.ule(bz));
+      EXPECT_EQ(a.ugt(b), az.ugt(bz));
+      EXPECT_EQ(a.uge(b), az.uge(bz));
+      EXPECT_EQ(a.slt(b), as.slt(bs));
+      EXPECT_EQ(a.sle(b), as.sle(bs));
+      EXPECT_EQ(a.sgt(b), as.sgt(bs));
+      EXPECT_EQ(a.sge(b), as.sge(bs));
+      EXPECT_EQ(a.comp(b).bits(), az.comp(bz).bits());
+      // Reduction operations depend on total width; forcing to large via
+      // extension changes the value, so we skip direct comparison here.
+    }
+  }
+}
+


### PR DESCRIPTION
- Added width-aware variant storage for BitVec, with helpers to mask and convert between small (≤64‑bit) and large representations
- Implemented lazy bit materialization for small values and fast native operations with overflow detection before falling back to the vector path
- Integrated Google Benchmark, microbenchmarks, and randomized property/fuzz tests to compare small and large behaviors across multiple widths
<img width="1728" height="1101" alt="image" src="https://github.com/user-attachments/assets/7a7409ba-fb73-48a3-825e-283a61e573fe" />
<img width="1728" height="1101" alt="image" src="https://github.com/user-attachments/assets/94545e4a-67b6-4126-a799-c5a84cb15828" />
<img width="1728" height="1101" alt="image" src="https://github.com/user-attachments/assets/f7c00f44-658e-41a9-a592-6dc039fbde79" />
<img width="1702" height="1101" alt="image" src="https://github.com/user-attachments/assets/f1eeb12d-0060-4134-a254-734f23fd1b2d" />
<img width="1702" height="1101" alt="image" src="https://github.com/user-attachments/assets/dfda2a0f-b225-4ea7-acfd-64a73e08438b" />
<img width="1728" height="1101" alt="image" src="https://github.com/user-attachments/assets/602e0ddf-737e-422a-8bd0-0bf3ab493925" />
