### PR TITLE
docs: clarify BitVec semantics

### DIFF
--- a/include/btgly/bitvec.hh
+++ b/include/btgly/bitvec.hh
@@ -17,363 +17,359 @@ namespace btgly {
 
   //*-- BitVec
 
-  /// \brief Fixed-width bit-vector with SMT-LIB–style semantics.
+  /// Fixed-width bit-vector with SMT-LIB–style semantics.
   class BitVec {
   public:
+    /// Create a zero-initialised bit-vector of the requested width.
+    //$ ensures width() == width
+    //$ ensures is_zero()
     explicit BitVec(std::size_t width);
 
+    /// Create a bit-vector of the given width filled with \p value.
+    //$ ensures width() == width
+    //$ ensures is_all_ones() == value
     BitVec(bool value, std::size_t width);
 
+    /// Return a zero-filled bit-vector of \p width bits.
+    //$ ensures result.width() == width
+    //$ ensures result.is_zero()
     static BitVec zeros(std::size_t width);
 
+    /// Return an all-ones bit-vector of \p width bits.
+    //$ ensures result.width() == width
+    //$ ensures result.is_all_ones()
     static BitVec ones(std::size_t width);
 
-    /// \brief Construct a bit-vector of \p width from an integer string.
-    ///
-    /// Parses \p integer as an unsigned integer in base 10 by default, or in
-    /// base 2/8/16 when prefixed with \c 0b / \c 0o / \c 0x respectively.
-    /// The value is reduced modulo 2^width (i.e., truncated to \p width bits).
-    ///
-    /// \param integer The textual integer value (e.g., "42", "0xff", "0b1010").
-    /// \param width   Number of bits (may be 0).
+    /// Construct a bit-vector of \p width from an integer string.
+    /// The string is parsed as unsigned decimal unless prefixed with
+    /// \c 0b / \c 0o / \c 0x for binary, octal or hexadecimal. A leading
+    /// '+' or '-' toggles the sign. The value is truncated to the low
+    /// \p width bits (i.e. taken modulo 2^width).
+    //$ ensures result.width() == width
+    //$ excepts invalid_argument if the string contains invalid digits
     static BitVec from_int(std::string s, std::size_t width);
 
     //*- properties
 
+    /// View the bits in least-significant-bit first order.
+    //$ ensures return.size() == width()
+    //$ ensures forall i : Int :: 0 <= i < width() => return[i] == bit(i)
     const std::vector<bool> &bits() const;
 
-    /// \brief Return the number of bits in this bit-vector.
+    /// Number of bits in this vector.
     std::size_t width() const;
 
+    /// True iff every bit equals one (width()==0 returns true).
+    //$ ensures return == forall i : Int :: 0 <= i < width() => bit(i)
     bool is_all_ones() const;
 
+    /// True iff every bit equals zero.
     bool is_zero() const;
 
+    /// True iff the most-significant bit is one and width()>0.
     bool is_negative() const;
 
+    /// True iff width()>0 and the value is 1000...0.
     bool is_most_negative() const;
 
     //*- methods
 
-    /// \brief Concatenate this bit-vector (high part) with \p rhs (low part).
-    ///
-    /// \param rhs Low-order bits to append.
-    /// \returns A new bit-vector of combined width.
+    /// Concatenate this bit-vector (high part) with \p rhs (low part).
+    //$ requires true
+    //$ ensures result.width() == width() + rhs.width()
     BitVec concat(const BitVec &rhs) const;
 
-    /// \brief Extract bits \c [i : j] (inclusive), with \c i >= j.
-    ///
-    /// Uses 0-based indexing where bit 0 is LSB. The result has width \c i-j+1
-    /// with result[0] = original bit \c j.
-    ///
-    /// \param i High bit index (inclusive).
-    /// \param j Low bit index  (inclusive).
-    /// \returns A new bit-vector of width \c (i - j + 1).
+    /// Extract bits [i:j] (inclusive) with i >= j.
+    //$ requires j <= i && i < width()
+    //$ ensures result.width() == i - j + 1
+    //$ excepts invalid_argument when i < j || i >= width()
     BitVec extract(std::size_t i, std::size_t j) const;
 
-    /// \brief Repeat this bit-vector \p k times by concatenation.
-    ///
-    /// \param k Number of repetitions (k >= 0). If \p k == 0, the result has
-    /// width 0.
-    /// \returns A new bit-vector of width \c k * this->width().
+    /// Repeat this bit-vector k times by concatenation.
+    //$ ensures result.width() == k * width()
     BitVec repeat(std::size_t k) const;
 
-    /// \brief Sign-extend by \p k bits (two's-complement).
-    ///
-    /// High bits of the result are filled with the sign bit (original bit
-    /// \c width()-1). Result width is \c width()+k.
-    ///
-    /// \param k Number of bits to add.
+    /// Sign-extend by k bits (two's-complement).
+    //$ ensures result.width() == width() + k
     BitVec sign_extend(std::size_t k) const;
 
-    /// \brief Zero-extend by \p k bits.
-    ///
-    /// High bits of the result are filled with zeros. Result width is
-    /// \c width()+k.
-    ///
-    /// \param k Number of bits to add.
+    /// Zero-extend by k bits.
+    //$ ensures result.width() == width() + k
     BitVec zero_extend(std::size_t k) const;
 
-    /// \brief Rotate left by \p k (mod \c width()).
-    ///
-    /// \param k Rotation amount (any size; taken modulo \c width()).
-    /// \returns A bitwise rotation; width unchanged.
+    /// Rotate left by \p k (mod \c width()).
+    //$ ensures result.width() == width()
     BitVec rotate_left(std::size_t k) const;
 
-    /// \brief Rotate right by \p k (mod \c width()).
-    ///
-    /// \param k Rotation amount (any size; taken modulo \c width()).
-    /// \returns A bitwise rotation; width unchanged.
+    /// Rotate right by \p k (mod \c width()).
+    //$ ensures result.width() == width()
     BitVec rotate_right(std::size_t k) const;
 
-    /// \brief Bitwise NOT (~).
-    ///
-    /// \returns A bit-vector where each bit is inverted.
+    /// Bitwise NOT.
+    //$ ensures result.width() == width()
+    //$ ensures forall i : Int :: 0 <= i < width() =>
+    //$   result.bit(i) == !bit(i)
     BitVec $not() const;
 
-    /// \brief Bitwise AND.
-    ///
-    /// \param rhs Right-hand operand (same width).
-    /// \returns \c (*this) & rhs.
+    /// Bitwise AND.
+    //$ requires rhs.width() == width()
+    //$ ensures result.width() == width()
+    //$ ensures forall i : Int :: 0 <= i < width() =>
+    //$   result.bit(i) == (bit(i) && rhs.bit(i))
     BitVec $and(const BitVec &rhs) const;
 
-    /// \brief Bitwise OR.
-    ///
-    /// \param rhs Right-hand operand (same width).
-    /// \returns \c (*this) | rhs.
+    /// Bitwise OR.
+    //$ requires rhs.width() == width()
+    //$ ensures result.width() == width()
+    //$ ensures forall i : Int :: 0 <= i < width() =>
+    //$   result.bit(i) == (bit(i) || rhs.bit(i))
     BitVec $or(const BitVec &rhs) const;
 
-    /// \brief Bitwise XOR.
-    ///
-    /// \param rhs Right-hand operand (same width).
-    /// \returns \c (*this) ^ rhs.
+    /// Bitwise XOR.
+    //$ requires rhs.width() == width()
+    //$ ensures result.width() == width()
+    //$ ensures forall i : Int :: 0 <= i < width() =>
+    //$   result.bit(i) == (bit(i) ^ rhs.bit(i))
     BitVec $xor(const BitVec &rhs) const;
 
-    /// \brief Bitwise NAND: NOT(AND).
-    ///
-    /// \param rhs Right-hand operand (same width).
-    /// \returns \c ~((*this) & rhs).
+    /// Bitwise NAND: NOT(AND).
+    //$ requires rhs.width() == width()
+    //$ ensures result.width() == width()
     BitVec nand(const BitVec &rhs) const;
 
-    /// \brief Bitwise NOR: NOT(OR).
-    ///
-    /// \param rhs Right-hand operand (same width).
-    /// \returns \c ~((*this) | rhs).
+    /// Bitwise NOR: NOT(OR).
+    //$ requires rhs.width() == width()
+    //$ ensures result.width() == width()
     BitVec nor(const BitVec &rhs) const;
 
-    /// \brief Bitwise XNOR: NOT(XOR).
-    ///
-    /// \param rhs Right-hand operand (same width).
-    /// \returns \c ~((*this) ^ rhs).
+    /// Bitwise XNOR: NOT(XOR).
+    //$ requires rhs.width() == width()
+    //$ ensures result.width() == width()
     BitVec xnor(const BitVec &rhs) const;
 
-    /// \brief Reduction AND.
-    ///
-    /// \returns \c true iff all bits are 1 (width==0 returns \c true).
+    /// Reduction AND.
+    //$ ensures return == forall i : Int :: 0 <= i < width() => bit(i)
     bool redand() const;
 
-    /// \brief Reduction OR.
-    ///
-    /// \returns \c true iff any bit is 1 (width==0 returns \c false).
+    /// Reduction OR.
+    //$ ensures return == exists i : Int :: 0 <= i < width() && bit(i)
     bool redor() const;
 
-    /// \brief Two's-complement negation.
-    ///
-    /// Equivalent to \c (~x + 1) modulo 2^width. Overflow (negation overflow)
-    /// occurs only for the most-negative value (1000...0).
+    /// Two's-complement negation (modular).
+    //$ ensures result.width() == width()
     BitVec neg() const;
 
-    /// \brief Unsigned/signed-agnostic modular addition.
-    ///
-    /// Result is \c (*this + rhs) mod 2^width.
+    /// Modular addition.
+    //$ requires rhs.width() == width()
+    //$ ensures result.width() == width()
     BitVec add(const BitVec &rhs) const;
 
-    /// \brief Unsigned/signed-agnostic modular subtraction.
-    ///
-    /// Result is \c (*this - rhs) mod 2^width.
+    /// Modular subtraction.
+    //$ requires rhs.width() == width()
+    //$ ensures result.width() == width()
     BitVec sub(const BitVec &rhs) const;
 
-    /// \brief Unsigned/signed-agnostic modular multiplication.
-    ///
-    /// Result is \c (*this * rhs) mod 2^width.
+    /// Modular multiplication.
+    //$ requires rhs.width() == width()
+    //$ ensures result.width() == width()
     BitVec mul(const BitVec &rhs) const;
 
-    /// \brief Unsigned division (SMT-LIB \c bvudiv semantics), Div/0 -> all ones.
-    ///
-    /// \param rhs Divisor.
-    /// \returns \c floor(u(*this) / u(rhs)), where \c u is the unsigned value.
-    /// Division by zero yields a vector of all 1s.
+    /// Unsigned division (SMT-LIB bvudiv). Div/0 -> all ones.
+    //$ requires rhs.width() == width()
+    //$ ensures result.width() == width()
     BitVec udiv(const BitVec &rhs) const;
 
-    /// \brief Unsigned remainder (SMT-LIB \c bvurem semantics), Div/0 -> lhs.
-    ///
-    /// \param rhs Divisor.
-    /// \returns \c u(*this) mod u(rhs). If \p rhs is zero, returns \c *this.
+    /// Unsigned remainder (bvurem). Div/0 -> lhs.
+    //$ requires rhs.width() == width()
+    //$ ensures result.width() == width()
     BitVec urem(const BitVec &rhs) const;
 
-    /// \brief Signed division (two's-complement; SMT-LIB \c bvsdiv semantics).
-    /// Div/0 -> -1. Overflow (min / -1) -> min.
-    ///
-    /// \returns Truncating division toward zero on signed values. Division by
-    /// zero yields all 1s (i.e., -1). The overflow case (most-negative / -1)
-    /// returns most-negative.
+    /// Signed division (bvsdiv). Div/0 -> -1. Overflow -> min.
+    //$ requires rhs.width() == width()
+    //$ ensures result.width() == width()
     BitVec sdiv(const BitVec &rhs) const;
 
-    /// \brief Signed remainder (SMT-LIB \c bvsrem semantics).
-    /// Div/0 -> lhs. Overflow (min / -1) -> 0.
-    ///
-    /// \returns \c s(*this) - trunc(s(*this)/s(rhs)) * s(rhs), where \c s is the
-    /// signed value. If \p rhs is zero, returns \c *this. In the overflow case
-    /// (most-negative / -1), returns 0.
+    /// Signed remainder (bvsrem). Div/0 -> lhs.
+    //$ requires rhs.width() == width()
+    //$ ensures result.width() == width()
     BitVec srem(const BitVec &rhs) const;
 
-    /// \brief Signed modulo (SMT-LIB \c bvsmod semantics).
-    /// Div/0 -> lhs. Overflow (min / -1) -> 0.
-    ///
-    /// \returns A value with the sign of \p rhs and magnitude < |rhs|. If
-    /// \p rhs is zero, returns \c *this. In the overflow case
-    /// (most-negative / -1), returns 0.
+    /// Signed modulo (bvsmod). Div/0 -> lhs.
+    //$ requires rhs.width() == width()
+    //$ ensures result.width() == width()
     BitVec smod(const BitVec &rhs) const;
 
-    /// \brief Logical left shift by an unsigned amount in \p rhs.
-    ///
-    /// Shift amount is interpreted as an unsigned integer from \p rhs. If the
-    /// amount >= width, the result is all zeros.
+    /// Logical left shift by an unsigned amount in \p rhs.
+    //$ requires rhs.width() == width() || width() == 0
+    //$ ensures result.width() == width()
     BitVec shl(const BitVec &rhs) const;
 
-    /// \brief Logical right shift by an unsigned amount in \p rhs.
-    ///
-    /// Shift amount is interpreted as unsigned. If the amount >= width, the
-    /// result is all zeros.
+    /// Logical right shift by an unsigned amount in \p rhs.
+    //$ requires rhs.width() == width() || width() == 0
+    //$ ensures result.width() == width()
     BitVec lshr(const BitVec &rhs) const;
 
-    /// \brief Arithmetic right shift by an unsigned amount in \p rhs.
-    ///
-    /// Vacated bits are filled with the sign bit. If the amount >= width, the
-    /// result is all sign bits (all 0s for non-negative, all 1s for negative).
+    /// Arithmetic right shift by an unsigned amount in \p rhs.
+    //$ requires rhs.width() == width() || width() == 0
+    //$ ensures result.width() == width()
     BitVec ashr(const BitVec &rhs) const;
 
-    /// \brief Unsigned comparison: \c *this < rhs.
+    /// Unsigned comparison: *this < rhs.
+    //$ requires rhs.width() == width()
     bool ult(const BitVec &rhs) const;
 
-    /// \brief Unsigned comparison: \c *this \<= rhs.
+    /// Unsigned comparison: *this <= rhs.
+    //$ requires rhs.width() == width()
     bool ule(const BitVec &rhs) const;
 
-    /// \brief Unsigned comparison: \c *this \>= rhs.
+    /// Unsigned comparison: *this >= rhs.
+    //$ requires rhs.width() == width()
     bool uge(const BitVec &rhs) const;
 
-    /// \brief Unsigned comparison: \c *this > rhs.
+    /// Unsigned comparison: *this > rhs.
+    //$ requires rhs.width() == width()
     bool ugt(const BitVec &rhs) const;
 
+    /// Equality check.
+    //$ requires rhs.width() == width()
     bool eq(const BitVec &rhs) const;
 
+    /// Equality check (alias).
+    //$ requires rhs.width() == width()
     bool equals(const BitVec &rhs) const;
 
-    /// \brief Signed comparison: \c *this < rhs.
+    /// Signed comparison: *this < rhs.
+    //$ requires rhs.width() == width()
     bool slt(const BitVec &rhs) const;
 
-    /// \brief Signed comparison: \c *this \<= rhs.
+    /// Signed comparison: *this <= rhs.
+    //$ requires rhs.width() == width()
     bool sle(const BitVec &rhs) const;
 
-    /// \brief Signed comparison: \c *this \>= rhs.
+    /// Signed comparison: *this >= rhs.
+    //$ requires rhs.width() == width()
     bool sge(const BitVec &rhs) const;
 
-    /// \brief Signed comparison: \c *this > rhs.
+    /// Signed comparison: *this > rhs.
+    //$ requires rhs.width() == width()
     bool sgt(const BitVec &rhs) const;
 
-    /// \brief Bit-vector compare (SMT-LIB \c bvcomp).
-    ///
-    /// \returns A 1-bit vector equal to 1 iff \c *this == rhs, else 0.
+    /// Bit-vector compare (SMT-LIB bvcomp).
+    //$ requires rhs.width() == width()
+    //$ ensures result.width() == 1
     BitVec comp(const BitVec &rhs) const;
 
-    /// \brief Negation overflow predicate.
-    ///
-    /// \returns \c true iff \c *this is the most-negative two's-complement value.
+    /// Negation overflow predicate.
+    //$ ensures return == is_most_negative()
     bool nego() const;
 
-    /// \brief Unsigned addition overflow.
-    ///
-    /// \returns \c true iff \c u(*this) + u(rhs) >= 2^width.
+    /// Unsigned addition overflow.
+    //$ requires rhs.width() == width()
     bool uaddo(const BitVec &rhs) const;
 
-    /// \brief Signed addition overflow.
-    ///
-    /// \returns \c true iff adding as signed two's-complement overflows.
+    /// Signed addition overflow.
+    //$ requires rhs.width() == width()
     bool saddo(const BitVec &rhs) const;
 
-    /// \brief Unsigned multiplication overflow.
-    ///
-    /// \returns \c true iff the full unsigned product does not fit in \c width
-    /// bits (i.e., any high bits beyond width are non-zero).
+    /// Unsigned multiplication overflow.
+    //$ requires rhs.width() == width()
     bool umulo(const BitVec &rhs) const;
 
-    /// \brief Signed multiplication overflow.
-    ///
-    /// \returns \c true iff the exact two's-complement product cannot be
-    /// represented in \c width bits.
+    /// Signed multiplication overflow.
+    //$ requires rhs.width() == width()
     bool smulo(const BitVec &rhs) const;
 
-    /// \brief Unsigned subtraction overflow (borrow).
-    ///
-    /// \returns \c true iff \c u(*this) < u(rhs) (i.e., a borrow occurs).
+    /// Unsigned subtraction overflow (borrow).
+    //$ requires rhs.width() == width()
     bool usubo(const BitVec &rhs) const;
 
-    /// \brief Signed subtraction overflow.
-    ///
-    /// \returns \c true iff subtracting as signed two's-complement overflows.
+    /// Signed subtraction overflow.
+    //$ requires rhs.width() == width()
     bool ssubo(const BitVec &rhs) const;
 
-    /// \brief Signed division overflow.
-    ///
-    /// \returns \c true iff \c *this is most-negative and \p rhs is -1 (the only
-    /// overflowing signed divide in two's-complement).
+    /// Signed division overflow.
+    //$ requires rhs.width() == width()
     bool sdivo(const BitVec &rhs) const;
 
-    /// \brief Return the unsigned decimal string representation.
-    ///
-    /// \returns The value interpreted as an unsigned integer, in base 10.
+    /// Return the unsigned decimal string representation.
+    //$ ensures return.size() > 0
     std::string u_to_int() const;
 
-    /// \brief Return the signed decimal string representation.
-    ///
-    /// \returns The value interpreted as a signed two's-complement integer,
-    /// in base 10.
+    /// Return the signed decimal string representation.
+    //$ ensures return.size() > 0
     std::string s_to_int() const;
 
   private:
+    /// Number of significant bits in the vector.
     std::size_t _width{0};
 
-    /// Inline representation for bit-vectors of width \<= 64.
+    /// Inline representation for vectors of width <= 64 bits.
     using Small = std::uint64_t;
-    /// Dynamic representation for wider bit-vectors.
+    /// Dynamic representation for wider vectors, stored LSB-first.
     using Large = std::vector<bool>;
 
-    /// Variant storage holding either small or large representation.
+    /// Storage variant holding either a Small or Large representation.
     mutable std::variant<Small, Large> _storage;
-    /// Cached materialization of bits for small values (LSB-first).
+    /// Cached view of bits for Small values.
     mutable std::optional<Large> _cached_bits;
 
+    /// Mask with the low \p w bits set.
     static constexpr Small mask(std::size_t w) noexcept;
+    /// Trim a Small value to width \p w.
     static constexpr Small trim(Small v, std::size_t w) noexcept;
+    /// True if the value fits in the Small representation.
     constexpr bool is_small() const noexcept;
+    /// Access the Small value (only valid if is_small()).
     constexpr Small as_small() const noexcept;
+    /// Mutable reference to the Large representation.
     constexpr Large &large_ref() noexcept;
+    /// Const reference to the Large representation.
     constexpr const Large &large_ref() const noexcept;
 
+    /// Return true if decimal string \p s represents zero.
     static bool _is_decimal_zero(const std::string &s);
 
+    /// Divide decimal string \p s by two, returning the remainder bit.
     static int _div_decimal_by_2(std::string &s);
 
+    /// Remove leading zeros from decimal string \p s.
     static void _trim_leading_zeros(std::string &s);
 
-    // Add a*b into 'acc' (acc has size >= a.size()+b.size())
+    /// Multiply \p a and \p b (LSB-first) and accumulate into \p acc.
     static void _mul(std::vector<bool> &acc, const std::vector<bool> &a, const std::vector<bool> &b);
 
-    // TODO: static + rename to ucomp
+    /// Unsigned lexicographic comparison.
     static int _compare_unsigned(const BitVec &a, const BitVec &b);
 
-    // Unsigned division: compute quotient q (size w) and remainder r (dynamic).
+    /// Unsigned division: compute quotient \p q and remainder \p r.
     static void _udivrem_bits(const std::vector<bool> &num, const std::vector<bool> &den, std::vector<bool> &q,
                               std::vector<bool> &r);
 
-    // Compare arbitrary-length LSB-first vectors (unsigned).
+    /// Compare two arbitrary-length vectors (unsigned).
     static int _cmp_arb_unsigned(const std::vector<bool> &a, const std::vector<bool> &b);
 
-    // a -= b, assumes a >= b (unsigned), arbitrary-length LSB-first.
+    /// In-place subtraction of \p b from \p a assuming a >= b.
     static void _sub_arb_unsigned_in_place(std::vector<bool> &a, const std::vector<bool> &b);
 
+    /// Drop leading zero bits from \p v.
     static void _trim_bits(std::vector<bool> &v);
 
+    /// Index of most significant set bit or -1 if none.
     static int _msb_index(const std::vector<bool> &v);
 
+    /// Decimal helper: s = s * mul + add.
     static void _dec_mul_add(std::string &s, int mul, int add);
 
+    /// Reduce \p amt modulo \p mod.
     static std::size_t _rhs_amount_mod(const BitVec &amt, std::size_t mod);
 
+    /// Return true if \p amt >= width \p w.
     static bool _rhs_amount_ge_width(const BitVec &amt, std::size_t w);
 
+    /// Materialise bits in LSB-first order.
     std::vector<bool> &_bits() const;
 
+    /// Throw if widths differ in operation \p op.
     void _ensure_same_width(const BitVec &rhs, const char *op) const;
   };
 

--- a/src/bitvec.cc
+++ b/src/bitvec.cc
@@ -31,7 +31,8 @@ namespace btgly {
   BitVec BitVec::ones(std::size_t width) { return {true, width}; }
 
   BitVec BitVec::from_int(std::string s, std::size_t width) {
-    // TODO: specify
+    // Parse textual integer with optional sign and base prefix.
+    // Digits beyond the target width are discarded (mod 2^width).
     // TODO: deal with empty or illegal string
     // determine negativeness
     bool neg = false;
@@ -160,7 +161,7 @@ namespace btgly {
   }
 
   BitVec BitVec::extract(std::size_t i, std::size_t j) const {
-    // TODO: specify
+    // Copy bits in the inclusive range [j,i] into a fresh BitVec.
     if(i < j) { throw std::invalid_argument("extract: i < j"); }
     if(i >= this->_width) { throw std::out_of_range("extract: high index out of range"); }
     const std::size_t w = i - j + 1;
@@ -180,7 +181,7 @@ namespace btgly {
   }
 
   BitVec BitVec::repeat(std::size_t k) const {
-    // TODO: specify
+    // Concatenate this vector with itself k times.
     if(k == 0) { return BitVec::zeros(0); }
     BitVec result(_width * k);
     for(std::size_t r = 0; r < k; ++r) {
@@ -198,7 +199,7 @@ namespace btgly {
   }
 
   BitVec BitVec::sign_extend(std::size_t k) const {
-    // TODO: specify
+    // Append k copies of the sign bit to the high end.
     BitVec result(false, this->_width + k);
     const bool sign = _width != 0 && _bits()[_width - 1];
     for(std::size_t i = 0; i < this->_width; ++i) { result._bits()[i] = _bits()[i]; }
@@ -215,7 +216,7 @@ namespace btgly {
   }
 
   BitVec BitVec::zero_extend(std::size_t k) const {
-    // TODO: specify
+    // Extend width by k with zeros in the high bits.
     BitVec result(false, _width + k);
     for(std::size_t i = 0; i < _width; ++i) { result._bits()[i] = _bits()[i]; }
     if(result.is_small()) {
@@ -230,7 +231,7 @@ namespace btgly {
   }
 
   BitVec BitVec::rotate_left(std::size_t k) const {
-    // TODO: specify
+    // Rotate bits left by k positions modulo width.
     const std::size_t w = _width;
     if(w == 0) return BitVec(0);
     k %= w;
@@ -263,7 +264,7 @@ namespace btgly {
   }
 
   BitVec BitVec::rotate_right(std::size_t k) const {
-    // TODO: specify
+    // Rotate bits right by k positions modulo width.
     const std::size_t w = _width;
     if(w == 0) return BitVec(0);
     k %= w;
@@ -379,7 +380,7 @@ namespace btgly {
   }
 
   BitVec BitVec::nand(const BitVec &rhs) const {
-    // TODO: specify
+    // Compute ~(this & rhs).
     if(!(is_small() && rhs.is_small())) {
       BitVec result(_width);
       Large &out = result.large_ref();
@@ -397,7 +398,7 @@ namespace btgly {
   }
 
   BitVec BitVec::nor(const BitVec &rhs) const {
-    // TODO: specify
+    // Compute ~(this | rhs).
     if(!(is_small() && rhs.is_small())) {
       BitVec result(_width);
       Large &out = result.large_ref();
@@ -415,7 +416,7 @@ namespace btgly {
   }
 
   BitVec BitVec::xnor(const BitVec &rhs) const {
-    // TODO: specify
+    // Compute ~(this ^ rhs).
     if(!(is_small() && rhs.is_small())) {
       BitVec result(_width);
       Large &out = result.large_ref();
@@ -433,7 +434,7 @@ namespace btgly {
   }
 
   bool BitVec::redand() const {
-    // TODO: specify
+    // Return true iff every bit is 1.
     if(!is_small()) {
       for(bool b: _bits()) {
         if(!b) { return false; }
@@ -457,7 +458,7 @@ namespace btgly {
 
   BitVec BitVec::neg() const {
     //$ ensures return._width == this._width
-    // TODO: specify
+    // Two's complement negation via bitwise not plus one.
     if(!is_small()) {
       BitVec result(_width);
       Large &out = result.large_ref();
@@ -480,7 +481,7 @@ namespace btgly {
   BitVec BitVec::add(const BitVec &rhs) const {
     //$ requires rhs._width == this._width
     //$ ensures return._width == this._width
-    // TODO: specify
+    // Ripple-carry addition modulo 2^width.
     _ensure_same_width(rhs, "add");
     if(!(is_small() && rhs.is_small())) {
       BitVec result(_width);
@@ -504,7 +505,7 @@ namespace btgly {
   BitVec BitVec::sub(const BitVec &rhs) const {
     //$ requires rhs._width == this._width
     //$ ensures return._width == this._width
-    // TODO: specify
+    // Subtract rhs from this using borrow propagation.
     _ensure_same_width(rhs, "sub");
     if(!(is_small() && rhs.is_small())) {
       BitVec result(_width);
@@ -526,7 +527,7 @@ namespace btgly {
   }
 
   BitVec BitVec::mul(const BitVec &rhs) const {
-    // TODO: specify
+    // Multiply two bit-vectors modulo 2^width.
     _ensure_same_width(rhs, "mul");
     const std::size_t w = this->_width;
     if(is_small() && rhs.is_small()) {
@@ -549,7 +550,7 @@ namespace btgly {
   }
 
   BitVec BitVec::udiv(const BitVec &rhs) const {
-    // TODO: specify
+    // Unsigned division with divisor 0 producing all ones.
     _ensure_same_width(rhs, "udiv");
     const std::size_t w = _width;
     if(is_small() && rhs.is_small()) {
@@ -579,7 +580,7 @@ namespace btgly {
   }
 
   BitVec BitVec::urem(const BitVec &rhs) const {
-    // TODO: specify
+    // Unsigned remainder; divisor 0 returns *this.
     _ensure_same_width(rhs, "urem");
     const std::size_t w = _width;
     if(is_small() && rhs.is_small()) {
@@ -604,7 +605,7 @@ namespace btgly {
   }
 
   BitVec BitVec::sdiv(const BitVec &rhs) const {
-    // TODO: specify
+    // Signed division truncating toward zero.
     _ensure_same_width(rhs, "sdiv");
     const std::size_t w = _width;
     if(is_small() && rhs.is_small()) {
@@ -649,7 +650,7 @@ namespace btgly {
   }
 
   BitVec BitVec::srem(const BitVec &rhs) const {
-    // TODO: specify
+    // Signed remainder with sign of dividend.
     _ensure_same_width(rhs, "srem");
     const std::size_t w = _width;
     if(is_small() && rhs.is_small()) {
@@ -687,7 +688,7 @@ namespace btgly {
   }
 
   BitVec BitVec::smod(const BitVec &rhs) const {
-    // TODO: specify
+    // Signed modulo with sign of divisor.
     _ensure_same_width(rhs, "smod");
     const std::size_t w = _width;
     if(is_small() && rhs.is_small()) {
@@ -728,8 +729,8 @@ namespace btgly {
   }
 
   BitVec BitVec::shl(const BitVec &rhs) const {
-    // TODO: specify
-    _ensure_same_width(rhs, "shl");
+    // Logical left shift by the amount given in rhs.
+    if(_width != 0) _ensure_same_width(rhs, "shl");
     const std::size_t w = _width;
     if(is_small() && rhs.is_small()) {
       auto amt = static_cast<std::size_t>(rhs.as_small());
@@ -756,8 +757,8 @@ namespace btgly {
   }
 
   BitVec BitVec::lshr(const BitVec &rhs) const {
-    // TODO: specify
-    _ensure_same_width(rhs, "lshr");
+    // Logical right shift by the amount in rhs.
+    if(_width != 0) _ensure_same_width(rhs, "lshr");
     const std::size_t w = _width;
     if(is_small() && rhs.is_small()) {
       auto amt = static_cast<std::size_t>(rhs.as_small());
@@ -786,8 +787,8 @@ namespace btgly {
   }
 
   BitVec BitVec::ashr(const BitVec &rhs) const {
-    // TODO: specify
-    _ensure_same_width(rhs, "ashr");
+    // Arithmetic right shift preserving the sign bit.
+    if(_width != 0) _ensure_same_width(rhs, "ashr");
     const std::size_t w = _width;
     const bool sign = is_negative();
     if(is_small() && rhs.is_small()) {
@@ -817,7 +818,7 @@ namespace btgly {
   }
 
   bool BitVec::ult(const BitVec &rhs) const {
-    // TODO: specify
+    // Unsigned comparison: this < rhs.
     _ensure_same_width(rhs, "ult");
     if(is_small() && rhs.is_small()) {
       Small lhs = trim(as_small(), _width);
@@ -828,7 +829,7 @@ namespace btgly {
   }
 
   bool BitVec::ule(const BitVec &rhs) const {
-    // TODO: specify
+    // Unsigned comparison: this <= rhs.
     _ensure_same_width(rhs, "ule");
     if(is_small() && rhs.is_small()) {
       Small lhs = trim(as_small(), _width);
@@ -839,7 +840,7 @@ namespace btgly {
   }
 
   bool BitVec::uge(const BitVec &rhs) const {
-    // TODO: specify
+    // Unsigned comparison: this >= rhs.
     _ensure_same_width(rhs, "uge");
     if(is_small() && rhs.is_small()) {
       Small lhs = trim(as_small(), _width);
@@ -850,7 +851,7 @@ namespace btgly {
   }
 
   bool BitVec::ugt(const BitVec &rhs) const {
-    // TODO: specify
+    // Unsigned comparison: this > rhs.
     _ensure_same_width(rhs, "ugt");
     if(is_small() && rhs.is_small()) {
       Small lhs = trim(as_small(), _width);
@@ -872,7 +873,7 @@ namespace btgly {
   }
 
   bool BitVec::slt(const BitVec &rhs) const {
-    // TODO: specify
+    // Signed comparison: this < rhs.
     _ensure_same_width(rhs, "slt");
     if(is_small() && rhs.is_small()) {
       if(_width == 0) return false;
@@ -891,7 +892,7 @@ namespace btgly {
   }
 
   bool BitVec::sle(const BitVec &rhs) const {
-    // TODO: specify
+    // Signed comparison: this <= rhs.
     _ensure_same_width(rhs, "sle");
     if(is_small() && rhs.is_small()) {
       if(_width == 0) return true;
@@ -910,7 +911,7 @@ namespace btgly {
   }
 
   bool BitVec::sge(const BitVec &rhs) const {
-    // TODO: specify
+    // Signed comparison: this >= rhs.
     _ensure_same_width(rhs, "sge");
     if(is_small() && rhs.is_small()) {
       if(_width == 0) return true;
@@ -929,7 +930,7 @@ namespace btgly {
   }
 
   bool BitVec::sgt(const BitVec &rhs) const {
-    // TODO: specify
+    // Signed comparison: this > rhs.
     _ensure_same_width(rhs, "sgt");
     if(is_small() && rhs.is_small()) {
       if(_width == 0) return false;
@@ -960,7 +961,7 @@ namespace btgly {
   }
 
   bool BitVec::uaddo(const BitVec &rhs) const {
-    // TODO: specify
+    // Detect unsigned addition overflow.
     _ensure_same_width(rhs, "uaddo");
     if(is_small() && rhs.is_small()) {
       Small lhs = as_small();
@@ -978,7 +979,7 @@ namespace btgly {
   }
 
   bool BitVec::saddo(const BitVec &rhs) const {
-    // TODO: specify
+    // Detect signed addition overflow.
     _ensure_same_width(rhs, "saddo");
     if(_width == 0) return false;
     if(is_small() && rhs.is_small()) {
@@ -998,7 +999,7 @@ namespace btgly {
   }
 
   bool BitVec::umulo(const BitVec &rhs) const {
-    // TODO: specify
+    // Detect unsigned multiplication overflow.
     _ensure_same_width(rhs, "umulo");
     if(is_small() && rhs.is_small()) {
       unsigned __int128 prod = static_cast<unsigned __int128>(as_small()) * rhs.as_small();
@@ -1015,7 +1016,7 @@ namespace btgly {
   }
 
   bool BitVec::smulo(const BitVec &rhs) const {
-    // TODO: specify
+    // Detect signed multiplication overflow.
     _ensure_same_width(rhs, "smulo");
     const std::size_t w = _width;
     if(w == 0) return false;
@@ -1054,14 +1055,14 @@ namespace btgly {
   }
 
   bool BitVec::usubo(const BitVec &rhs) const {
-    // TODO: specify
+    // Detect unsigned subtraction overflow (borrow).
     _ensure_same_width(rhs, "usubo");
     if(is_small() && rhs.is_small()) { return as_small() < rhs.as_small(); }
     return ult(rhs);
   }
 
   bool BitVec::ssubo(const BitVec &rhs) const {
-    // TODO: specify
+    // Detect signed subtraction overflow.
     _ensure_same_width(rhs, "ssubo");
     if(_width == 0) return false;
     if(is_small() && rhs.is_small()) {
@@ -1081,7 +1082,7 @@ namespace btgly {
   }
 
   bool BitVec::sdivo(const BitVec &rhs) const {
-    // TODO: specify
+    // Detect signed division overflow (min / -1).
     _ensure_same_width(rhs, "sdivo");
     if(is_small() && rhs.is_small()) {
       if(_width == 0) return false;
@@ -1094,7 +1095,7 @@ namespace btgly {
   }
 
   std::string BitVec::u_to_int() const {
-    // TODO: specify
+    // Convert to unsigned decimal string.
     // Build decimal by scanning from MSB to LSB: s = s*2 + bit
     std::string s = "0";
     int msb = _msb_index(_bits());
@@ -1110,7 +1111,7 @@ namespace btgly {
   }
 
   std::string BitVec::s_to_int() const {
-    // TODO: specify
+    // Convert to signed decimal string.
     if(!is_negative()) { return u_to_int(); }
 
     // magnitude = two's-complement negation
@@ -1178,7 +1179,7 @@ namespace btgly {
 
   // TODO: + rename to ucomp
   int BitVec::_compare_unsigned(const BitVec &a, const BitVec &b) {
-    // TODO: specify
+    // Compare two bit-vectors as unsigned integers.
     // TODO: a.ensureSameWidth(b, "compare");
     const std::size_t w = a._width;
     for(std::size_t i = 0; i < w; ++i) {


### PR DESCRIPTION
## Summary
- rewrite `btgly::BitVec` API comments in LLVM style
- document pre/post/exception conditions with `//$ requires` and `//$ ensures`
- explain internal representation and helper utilities
- refine shift operations to permit zero-width vectors

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68b0895c37888320a1742edca2695106